### PR TITLE
Metric Block - Filter by group type

### DIFF
--- a/RockWeb/Plugins/cc_newspring/Blocks/Metrics/Metrics.ascx.cs
+++ b/RockWeb/Plugins/cc_newspring/Blocks/Metrics/Metrics.ascx.cs
@@ -307,7 +307,13 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.Metrics
             // filter by group context
             if ( GroupContext != null )
             {
-                metricValueQueryable = metricValueQueryable.Where( a => a.ForeignId == GroupContext.Id );
+                metricValueQueryable = metricValueQueryable.Where( a => a.Metric.ForeignId == GroupContext.Id );
+            }
+            else if( GroupTypeContext != null )
+            {
+                var groupTypeIds = new GroupTypeService( rockContext ).GetAllAssociatedDescendents( GroupTypeContext.Id ).Select( gt => gt.Id );
+                var groupIds = new GroupService( rockContext ).Queryable().Where( g => groupTypeIds.Contains( g.GroupTypeId ) ).Select( g => g.Id );
+                metricValueQueryable = metricValueQueryable.Where( mv => mv.Metric.ForeignId.HasValue && groupIds.Contains( mv.Metric.ForeignId.Value ) );
             }
 
             return metricValueQueryable.ToList();


### PR DESCRIPTION
1.) Fix bug where foreign id of metric value was being used, when the metric's foreign id is what is linked to the group.
2.) If there is not a group id set in context, allow filtering by group type.  This involves picking all grouptypes in the selected grouptype's heirarchy and then picking all groups that have those group types.