### PR TITLE
Feature staff giving report

### DIFF
--- a/Dev Tools/Sql/Report_Finance_StaffGiving.sql
+++ b/Dev Tools/Sql/Report_Finance_StaffGiving.sql
@@ -10,6 +10,10 @@
 
 /* ====================================================== */
 
+-- For testing in sql server management studio, uncomment here:
+DECLARE @StartDate AS NVARCHAR(MAX) = '2015-01-01';
+DECLARE @EndDate AS NVARCHAR(MAX) = '2015-12-31';
+
 DECLARE @today AS DATE = GETDATE();
 DECLARE @reportEndDate AS DATE = CONVERT(DATE, DATEADD(DAY, 1 - DATEPART(WEEKDAY, @today), @today));
 DECLARE @reportStartDate AS DATE = DATEADD(DAY, -6, @reportEndDate);
@@ -22,34 +26,69 @@ END
 
 DECLARE @staffGroupId AS INT = (SELECT Id FROM [Group] WHERE Name = 'RSR - Staff Workers');
 
-SELECT
-	staff.Id AS PersonId,
-	staff.LastName,
-	staff.FirstName,
-	pfa.PublicName AS Account,
-	SUM(ftd.Amount) AS TotalGiven
-FROM
-	GroupMember staffGM
-	JOIN Person staff ON staff.Id = staffGM.PersonId
-	JOIN Person givers ON givers.GivingGroupId = staff.GivingGroupId
-	JOIN PersonAlias giverAliases ON giverAliases.PersonId = givers.Id
-	LEFT JOIN FinancialTransaction ft ON ft.AuthorizedPersonAliasId = giverAliases.Id
-	LEFT JOIN FinancialTransactionDetail ftd ON ftd.TransactionId = ft.Id
-	LEFT JOIN FinancialAccount fa ON fa.Id = ftd.AccountId
-	LEFT JOIN FinancialAccount pfa ON fa.ParentAccountId = pfa.Id
-WHERE
-	staffGM.GroupId = @staffGroupId
-	AND staffGM.IsSystem = 0
-	AND staff.IsSystem = 0
-	AND ft.TransactionDateTime >= @reportStartDate
-	AND ft.TransactionDateTime <= @reportEndDate
-GROUP BY
-	staff.Id,
-	pfa.Id,
-	pfa.PublicName,
-	staff.FirstName,
-	staff.LastName
-ORDER BY
-	staff.LastName,
-	staff.FirstName,
-	pfa.PublicName;
+DECLARE @fundNames AS NVARCHAR(MAX) = (
+	SELECT 
+		CONVERT(NVARCHAR(MAX), '[' + pfa.PublicName + '],')
+	FROM 
+		GroupMember staffGM
+		JOIN Person staff ON staff.Id = staffGM.PersonId
+		JOIN Person givers ON givers.GivingGroupId = staff.GivingGroupId
+		JOIN PersonAlias giverAliases ON giverAliases.PersonId = givers.Id
+		LEFT JOIN FinancialTransaction ft ON ft.AuthorizedPersonAliasId = giverAliases.Id
+		LEFT JOIN FinancialTransactionDetail ftd ON ftd.TransactionId = ft.Id
+		LEFT JOIN FinancialAccount fa ON fa.Id = ftd.AccountId
+		LEFT JOIN FinancialAccount pfa ON fa.ParentAccountId = pfa.Id
+	WHERE 
+		staffGM.GroupId = @staffGroupId
+		AND staffGM.IsSystem = 0
+		AND staff.IsSystem = 0
+		AND ft.TransactionDateTime >= @reportStartDate
+		AND ft.TransactionDateTime <= @reportEndDate
+	GROUP BY
+		pfa.Id,
+		pfa.PublicName
+	ORDER BY 
+		pfa.PublicName
+	FOR XML PATH(''));
+
+SELECT @fundNames = LEFT(@fundNames, LEN(@fundNames) - 1);
+
+DECLARE @sql AS NVARCHAR(MAX) = CONCAT(N'
+	SELECT 
+		* 
+	FROM (
+		SELECT
+			staff.Id AS PersonId,
+			staff.LastName,
+			staff.FirstName,
+			pfa.PublicName AS Account,
+			SUM(ftd.Amount) AS TotalGiven
+		FROM
+			GroupMember staffGM
+			JOIN Person staff ON staff.Id = staffGM.PersonId
+			JOIN Person givers ON givers.GivingGroupId = staff.GivingGroupId
+			JOIN PersonAlias giverAliases ON giverAliases.PersonId = givers.Id
+			LEFT JOIN FinancialTransaction ft ON ft.AuthorizedPersonAliasId = giverAliases.Id
+			LEFT JOIN FinancialTransactionDetail ftd ON ftd.TransactionId = ft.Id
+			LEFT JOIN FinancialAccount fa ON fa.Id = ftd.AccountId
+			LEFT JOIN FinancialAccount pfa ON fa.ParentAccountId = pfa.Id
+		WHERE
+			staffGM.GroupId = ', @staffGroupId, N'
+			AND staffGM.IsSystem = 0
+			AND staff.IsSystem = 0
+			AND ft.TransactionDateTime >= CONVERT(DATE, ''', @reportStartDate, N''')
+			AND ft.TransactionDateTime <= CONVERT(DATE, ''', @reportEndDate, N''')
+		GROUP BY
+			staff.Id,
+			pfa.Id,
+			pfa.PublicName,
+			staff.FirstName,
+			staff.LastName
+	) AS DataTable
+	PIVOT (SUM(TotalGiven) FOR Account IN (', @fundNames, N')) AS PivotTable
+	ORDER BY
+		LastName,
+		FirstName;
+');
+
+EXEC SP_EXECUTESQL @sql;


### PR DESCRIPTION
Changes from Finance feedback:
- Account names pivot to fields rather than one per row
- Staff members are grouped into one line per family
- Non staff spouses are also included in the giving group name on each row