### PR TITLE
Cherry Pick: New Location Fix

### DIFF
--- a/RockWeb/Blocks/Core/LocationDetail.ascx.cs
+++ b/RockWeb/Blocks/Core/LocationDetail.ascx.cs
@@ -112,13 +112,15 @@ namespace RockWeb.Blocks.Core
                 // Rebuild the attribute controls on postback based on group type
                 if ( pnlDetails.Visible )
                 {
-                    string locationId = PageParameter("LocationId");
-
-                    if (!String.IsNullOrEmpty(locationId))
+                    int? locationId = PageParameter( "LocationId" ).AsIntegerOrNull();
+                    if ( locationId.HasValue && locationId.Value > 0 )
                     {
-                        var location = new LocationService(new RockContext()).Get(locationId.AsInteger());
-                        location.LoadAttributes();
-                        BuildAttributeEdits(location, true);
+                        var location = new LocationService(new RockContext()).Get( locationId.Value );
+                        if ( location != null )
+                        {
+                            location.LoadAttributes();
+                            BuildAttributeEdits( location, true );
+                        }
                     }
                    
                 }


### PR DESCRIPTION
There is a bug on production now that won't allow a user to create a new location on this page: https://rock.newspring.cc/page/307

This is because the query param `LocationId` is `0` for an uncreated location, which causes a null ref exception.