### PR TITLE
Updated core filters with new attribute lookup pattern

### DIFF
--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
@@ -65,7 +65,7 @@ namespace Rock.Workflow.Action.CheckIn
                 var ageRangeAttributeGuid = GetAttributeValue( action, "GroupAgeRangeAttribute" ).AsGuid();
                 if ( ageRangeAttributeGuid != Guid.Empty )
                 {
-                    ageRangeAttributeKey = AttributeCache.Read( ageRangeAttributeGuid, rockContext ).Key ?? string.Empty;
+                    ageRangeAttributeKey = AttributeCache.Read( ageRangeAttributeGuid, rockContext ).Key;
                 }
 
                 // log a warning if the attribute is missing or invalid

--- a/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsByAge.cs
@@ -33,7 +33,7 @@ namespace Rock.Workflow.Action.CheckIn
     [ExportMetadata( "ComponentName", "Filter Groups By Age" )]
     [BooleanField( "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", true, "", 0 )]
     [BooleanField( "Age Required", "Select 'Yes' if groups with an age filter should be removed/excluded when person does not have an age.", true, "", 1 )]
-    [AttributeField( "9BBFDA11-0D22-40D5-902F-60ADFBC88987", "Age Range Attribute", "Select the attribute used to define the age range of the group", true, false, "43511B8F-71D9-423A-85BF-D1CD08C1998E" )]
+    [AttributeField( "9BBFDA11-0D22-40D5-902F-60ADFBC88987", "Group Age Range Attribute", "Select the attribute used to define the age range of the group", true, false, "43511B8F-71D9-423A-85BF-D1CD08C1998E", order: 2 )]
     public class FilterGroupsByAge : CheckInActionComponent
     {
         /// <summary>
@@ -58,11 +58,18 @@ namespace Rock.Workflow.Action.CheckIn
             {
                 var remove = GetAttributeValue( action, "Remove" ).AsBoolean();
                 bool ageRequired = GetAttributeValue( action, "AgeRequired" ).AsBoolean( true );
-                var ageRangeAttributeGuid = GetAttributeValue( action, "AgeRangeAttribute" ).AsGuid();
 
-                if ( ageRangeAttributeGuid == Guid.Empty )
+                var ageRangeAttributeKey = string.Empty;
+                var ageRangeAttributeGuid = GetAttributeValue( action, "GroupAgeRangeAttribute" ).AsGuid();
+
+                // get the admin-selected attribute key instead of using a hardcoded key
+                if ( ageRangeAttributeGuid != Guid.Empty )
                 {
-                    throw new Exception( "The attribute, AgeRangeAttribute, is invalid for FilterGroupsByAge" );
+                    ageRangeAttributeKey = rockContext.Attributes.Where( a => a.Guid == ageRangeAttributeGuid ).Select( a => a.Key ).FirstOrDefault();
+                }
+                else
+                {
+                    action.AddLogEntry( string.Format( "The selected Age Range attribute is missing or invalid for '{0}'.", action.ActionType.Name ) );
                 }
 
                 foreach ( var person in family.People )
@@ -84,13 +91,7 @@ namespace Rock.Workflow.Action.CheckIn
                     {
                         foreach ( var group in groupType.Groups.ToList() )
                         {
-                            var ageRangeAttribute = group.Group.Attributes.FirstOrDefault( a => a.Value.Guid == ageRangeAttributeGuid );
-                            var ageRange = string.Empty;
-
-                            if ( !ageRangeAttribute.Equals( default( KeyValuePair<string, Web.Cache.AttributeCache> ) ) )
-                            {
-                                ageRange = group.Group.GetAttributeValue( ageRangeAttribute.Key ) ?? string.Empty;
-                            }
+                            var ageRange = group.Group.GetAttributeValue( ageRangeAttributeKey ).ToStringSafe();
 
                             var ageRangePair = ageRange.Split( new char[] { ',' }, StringSplitOptions.None );
                             string minAgeValue = null;

--- a/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
+++ b/Rock/Workflow/Action/CheckIn/FilterGroupsBySpecialNeeds.cs
@@ -34,11 +34,11 @@ namespace Rock.Workflow.Action.CheckIn
     [Description( "Removes (or excludes) the groups for each selected family member that are not specific to their special needs attribute." )]
     [Export( typeof( ActionComponent ) )]
     [ExportMetadata( "ComponentName", "Filter Groups By Special Needs" )]
-    [AttributeField( "72657ED8-D16E-492E-AC12-144C5E7567E7", "Person Special Needs Attribute", "Select the person-level attribute used to filter kids with special needs.", true, false, "8B562561-2F59-4F5F-B7DC-92B2BB7BB7CF" )]
-    [AttributeField( "9BBFDA11-0D22-40D5-902F-60ADFBC88987", "Group Special Needs Attribute", "Select the group-level attribute used to filter kids with special needs.", true, false, "9210EC95-7B85-4D11-A82E-0B677B32704E" )]
-    [BooleanField( "Remove (or exclude) Special Needs Groups", "If set to true, special-needs groups will be removed if the person is NOT special needs. This basically prevents non-special-needs kids from getting put into special needs classes.  Default true.", true, key: "RemoveSpecialNeedsGroups" )]
-    [BooleanField( "Remove (or exclude) Non-Special Needs Groups", "If set to true, non-special-needs groups will be removed if the person is special needs.  This basically prevents special needs kids from getting put into regular classes.  Default false.", false, key: "RemoveNonSpecialNeedsGroups" )]
-    [BooleanField( "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", true )]
+    [AttributeField( "72657ED8-D16E-492E-AC12-144C5E7567E7", "Person Special Needs Attribute", "Select the attribute used to filter special needs people.", true, false, "8B562561-2F59-4F5F-B7DC-92B2BB7BB7CF", order: 1 )]
+    [AttributeField( "9BBFDA11-0D22-40D5-902F-60ADFBC88987", "Group Special Needs Attribute", "Select the attribute used to filter special needs groups.", true, false, "9210EC95-7B85-4D11-A82E-0B677B32704E", order: 2 )]
+    [BooleanField( "Remove (or exclude) Special Needs Groups", "If set to true, special-needs groups will be removed if the person is NOT special needs. This basically prevents non-special-needs kids from getting put into special needs classes.  Default true.", true, key: "RemoveSpecialNeedsGroups", order: 3 )]
+    [BooleanField( "Remove (or exclude) Non-Special Needs Groups", "If set to true, non-special-needs groups will be removed if the person is special needs.  This basically prevents special needs kids from getting put into regular classes.  Default false.", false, key: "RemoveNonSpecialNeedsGroups", order: 4 )]
+    [BooleanField( "Remove", "Select 'Yes' if groups should be be removed.  Select 'No' if they should just be marked as excluded.", true, order: 5 )]
     public class FilterGroupsBySpecialNeeds : CheckInActionComponent
     {
         /// <summary>
@@ -60,10 +60,29 @@ namespace Rock.Workflow.Action.CheckIn
 
             var personSpecialNeedsKey = string.Empty;
             var groupSpecialNeedsKey = string.Empty;
+            var personSpecialNeedsGuid = GetAttributeValue( action, "PersonSpecialNeedsAttribute" ).AsGuid();
+            var groupSpecialNeedsGuid = GetAttributeValue( action, "GroupSpecialNeedsAttribute" ).AsGuid();
             bool removeSNGroups = GetAttributeValue( action, "RemoveSpecialNeedsGroups" ).AsBoolean( true );
             bool removeNonSNGroups = GetAttributeValue( action, "RemoveNonSpecialNeedsGroups" ).AsBoolean();
 
-            GetSpecialNeedsKeys( rockContext, action, out personSpecialNeedsKey, out groupSpecialNeedsKey );
+            // get the admin-selected attribute key instead of using a hardcoded key
+            if ( personSpecialNeedsGuid != Guid.Empty )
+            {
+                personSpecialNeedsKey = rockContext.Attributes.Where( a => a.Guid == personSpecialNeedsGuid ).Select( a => a.Key ).FirstOrDefault();
+            }
+            else
+            {
+                action.AddLogEntry( string.Format( "The selected Person Special Needs attribute is missing or invalid for '{0}'.", action.ActionType.Name ) );
+            }
+
+            if ( groupSpecialNeedsGuid != Guid.Empty )
+            {
+                groupSpecialNeedsKey = rockContext.Attributes.Where( a => a.Guid == groupSpecialNeedsGuid ).Select( a => a.Key ).FirstOrDefault();
+            }
+            else
+            {
+                action.AddLogEntry( string.Format( "The selected Group Special Needs attribute is missing or invalid for '{0}'.", action.ActionType.Name ) );
+            }
 
             var family = checkInState.CheckIn.Families.FirstOrDefault( f => f.Selected );
             if ( family != null )
@@ -116,43 +135,6 @@ namespace Rock.Workflow.Action.CheckIn
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Gets the special needs keys currently selected in the action attributes.
-        /// </summary>
-        /// <param name="rockContext">The rock context.</param>
-        /// <param name="action">The action.</param>
-        /// <param name="personSpecialNeedsKey">The person special needs key.</param>
-        /// <param name="groupSpecialNeedsKey">The group special needs key.</param>
-        /// <exception cref="System.Exception">
-        /// The selected Person Special Needs attribute is invalid for the FilterGroupsBySpecialNeeds workflow action.
-        /// or
-        /// The selected Group Special Needs attribute is invalid for the FilterGroupsBySpecialNeeds workflow action.
-        /// </exception>
-        private void GetSpecialNeedsKeys( RockContext rockContext, Model.WorkflowAction action, out string personSpecialNeedsKey, out string groupSpecialNeedsKey )
-        {
-            // verify Person SN Attribute is set
-            var personSpecialNeedsGuid = GetAttributeValue( action, "PersonSpecialNeedsAttribute" ).AsGuid();
-            if ( personSpecialNeedsGuid != Guid.Empty )
-            {
-                personSpecialNeedsKey = rockContext.Attributes.Where( a => a.Guid == personSpecialNeedsGuid ).Select( a => a.Key ).FirstOrDefault();
-            }
-            else
-            {
-                throw new Exception( "The selected Person Special Needs attribute is invalid for the FilterGroupsBySpecialNeeds workflow action." );
-            }
-
-            // verify Group SN Attribute is set
-            var groupSpecialNeedsGuid = GetAttributeValue( action, "GroupSpecialNeedsAttribute" ).AsGuid();
-            if ( groupSpecialNeedsGuid != Guid.Empty )
-            {
-                groupSpecialNeedsKey = rockContext.Attributes.Where( a => a.Guid == groupSpecialNeedsGuid ).Select( a => a.Key ).FirstOrDefault();
-            }
-            else
-            {
-                throw new Exception( "The selected Group Special Needs attribute is invalid for the FilterGroupsBySpecialNeeds workflow action." );
-            }
         }
     }
 }


### PR DESCRIPTION
@benwiley Another pattern change...

I like using the [IHasAttributes].GetAttributeValue method here as it abstracts some of the craziness of looking up values by key, which is especially prevalent on SelectByBestFit.  I also updated it to log when the selected attribute is empty, instead of throwing an exception.