### PR TITLE
Process Payments: "No elements in sequence" Error

### DIFF
--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -386,7 +386,7 @@ namespace Rock.Model
                                 transaction.Summary += "Note: Downloaded transaction amount was greater than the configured allocation amounts for the Scheduled Transaction.";
                                 var transactionDetail = transaction.TransactionDetails
                                     .OrderByDescending( d => d.Amount )
-                                    .First();
+                                    .FirstOrDefault();
                                 if ( transactionDetail == null && defaultAccount != null )
                                 {
                                     transactionDetail = new FinancialTransactionDetail();


### PR DESCRIPTION
`First` was throwing an exception because there were no transaction details in the sequence.  Changing to `FirstOrDefault` allows the next statement to create the detail with the default account.  While it seems odd that a transaction would not have details, the author of this code seems to have expected the case since that if statement checking for null is included.