### PR TITLE
Fix process recurring payments

### DIFF
--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -391,7 +391,7 @@ namespace Rock.Model
                                 {
                                     transactionDetail = new FinancialTransactionDetail();
                                     transactionDetail.AccountId = defaultAccount.Id;
-                                    transaction.TransactionDetails.Add(transactionDetail);
+                                    transaction.TransactionDetails.Add( transactionDetail );
                                 }
                                 if ( transactionDetail != null )
                                 {

--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -391,6 +391,7 @@ namespace Rock.Model
                                 {
                                     transactionDetail = new FinancialTransactionDetail();
                                     transactionDetail.AccountId = defaultAccount.Id;
+                                    transaction.TransactionDetails.Add(transactionDetail);
                                 }
                                 if ( transactionDetail != null )
                                 {


### PR DESCRIPTION
In the case of no schedule details (which is admittedly an odd case) no transaction details would exist.  In this conditional statement, the details is created but never added to the transaction.  Thus duplications continued to be added to the DB every time the job is run with a total amount of 0 since they have no details.