### PR TITLE
[Alpha] Update status of previously downloaded transactions if they changed

### DIFF
--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -508,10 +508,10 @@ namespace Rock.Model
                     ( totalReversals == 1 ? "payment was" : "payments were" ) );
             }
 
-            if (totalStatusChanges > 0)
+            if ( totalStatusChanges > 0 )
             {
                 sb.AppendFormat( "<li>{0} {1} previously downloaded but had a change of status.</li>", totalStatusChanges.ToString( "N0" ),
-                    ( totalAlreadyDownloaded == 1 ? "payment was" : "payments were" ) );
+                    ( totalStatusChanges == 1 ? "payment was" : "payments were" ) );
             }
 
             foreach ( var batchItem in batchSummary )

--- a/Rock/Model/FinancialScheduledTransactionService.Partial.cs
+++ b/Rock/Model/FinancialScheduledTransactionService.Partial.cs
@@ -239,6 +239,7 @@ namespace Rock.Model
             int totalNoScheduledTransaction = 0;
             int totalAdded = 0;
             int totalReversals = 0;
+            int totalStatusChanges = 0;
 
             var batches = new List<FinancialBatch>();
             var batchSummary = new Dictionary<Guid, List<Decimal>>();
@@ -451,6 +452,13 @@ namespace Rock.Model
                         else
                         {
                             totalAlreadyDownloaded++;
+
+                            foreach( var txn in txns.Where( t => t.Status != payment.Status || t.StatusMessage != payment.StatusMessage ) )
+                            {
+                                txn.Status = payment.Status;
+                                txn.StatusMessage = payment.StatusMessage;
+                                totalStatusChanges++;
+                            }
                         }
                     }
                     else
@@ -498,6 +506,12 @@ namespace Rock.Model
             {
                 sb.AppendFormat( "<li>{0} {1} added as a reversal to a previous transaction.</li>", totalReversals.ToString( "N0" ),
                     ( totalReversals == 1 ? "payment was" : "payments were" ) );
+            }
+
+            if (totalStatusChanges > 0)
+            {
+                sb.AppendFormat( "<li>{0} {1} previously downloaded but had a change of status.</li>", totalStatusChanges.ToString( "N0" ),
+                    ( totalAlreadyDownloaded == 1 ? "payment was" : "payments were" ) );
             }
 
             foreach ( var batchItem in batchSummary )


### PR DESCRIPTION
For previously downloaded transactions, check if the status changed.  If so, update it in the DB.