### PR TITLE
NMI Missing Transactions

### DIFF
--- a/RockWeb/Plugins/cc_newspring/Blocks/NMITransactions/NMITransactionMismatch.ascx
+++ b/RockWeb/Plugins/cc_newspring/Blocks/NMITransactions/NMITransactionMismatch.ascx
@@ -22,15 +22,14 @@
                         <Rock:ModalAlert ID="mdGridWarning" runat="server" />
 
                         <Rock:Grid ID="gTransactions" runat="server" EmptyDataText="No Transactions Found" 
-                            RowItemText="Transaction" AllowSorting="true" ExportSource="ColumnOutput" >
+                            RowItemText="Transaction" ExportSource="ColumnOutput" AllowSorting="true" >
                             <Columns>
                                 <Rock:RockBoundField DataField="Name" HeaderText="Name" SortExpression="Name" />
-                                <Rock:RockBoundField DataField="EmailAddress" HeaderText="Email Address" SortExpression="EmalAddress" />
+                                <Rock:RockBoundField DataField="EmailAddress" HeaderText="Email Address" SortExpression="EmailAddress" />
                                 <Rock:RockBoundField DataField="TransactionDateTime" HeaderText="Date / Time" SortExpression="TransactionDateTime" />
                                 <Rock:CurrencyField DataField="Amount" HeaderText="Amount" SortExpression="Amount" />
                                 <Rock:RockBoundField DataField="TransactionCode" HeaderText="Transaction Code" SortExpression="TransactionCode" ColumnPriority="DesktopSmall" />
-                                <Rock:RockBoundField DataField="Status" HeaderText="Transaction Status"
-                                SortExpression="Status" />
+                                <Rock:RockBoundField DataField="Status" HeaderText="Transaction Status" SortExpression="Status" />
                                 <Rock:RockBoundField DataField="StatusMessage" HeaderText="Status Message" SortExpression="StatusMessage" />
                             </Columns>
                         </Rock:Grid>

--- a/RockWeb/Plugins/cc_newspring/Blocks/NMITransactions/NMITransactionMismatch.ascx.cs
+++ b/RockWeb/Plugins/cc_newspring/Blocks/NMITransactions/NMITransactionMismatch.ascx.cs
@@ -55,6 +55,8 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.NMITransactions
             gfTransactions.ApplyFilterClick += gfTransactions_ApplyFilterClick;
             gfTransactions.ClearFilterClick += gfTransactions_ClearFilterClick;
             gfTransactions.DisplayFilterValue += gfTransactions_DisplayFilterValue;
+            gTransactions.GridRebind += gTransactions_GridRebind;
+            gTransactions.GridReorder += gTransactions_GridReorder;
             if ( !Page.IsPostBack)
             {
                 string title = GetAttributeValue( "Title" );
@@ -67,6 +69,16 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.NMITransactions
                 BindFilter();
                 BindGrid();
             }
+        }
+
+        private void gTransactions_GridReorder( object sender, GridReorderEventArgs e )
+        {
+            //BindGrid();
+        }
+
+        private void gTransactions_GridRebind( object sender, GridRebindEventArgs e )
+        {
+            BindGrid();
         }
 
         private void gfTransactions_DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
@@ -143,6 +155,7 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.NMITransactions
                 var transactionsInRock = transactionService.Queryable();
                 FinancialTransactionDetailService transactionDetailService = new FinancialTransactionDetailService( rockContext );
                 var transactionDetailsInRock = transactionDetailService.Queryable();
+                SortProperty sort = gTransactions.SortProperty;
 
                 // Get a list of all transactions from NMI that do not have a matching transaction
                 // code in Rock.
@@ -176,6 +189,16 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.NMITransactions
                 // display in the block grid.
                 List<FinancialTransaction> transactionsToList = missing.Union( wrongAmount ).ToList();
 
+                SortProperty sortProperty = gTransactions.SortProperty;
+                if ( sortProperty != null)
+                {
+                    transactionsToList.AsQueryable().Sort( sortProperty );
+                }
+                else
+                {
+                    transactionsToList.OrderByDescending( t => t.TransactionDateTime ).ThenByDescending( t => t.TransactionCode );
+                }
+
                 // Show the transactions that are left after the filtering in the grid.
                 gTransactions.DataSource = transactionsToList.Select( t => new
                 {
@@ -187,6 +210,7 @@ namespace RockWeb.Plugins.cc_newspring.Blocks.NMITransactions
                     t.Status,
                     t.StatusMessage
                 } ).ToList();
+
                 gTransactions.DataBind();
             }
         }


### PR DESCRIPTION
This PR creates a block that:
(a) displays transactions from NMI that do not have matching transaction codes in Rock.
(b) displays transactions from NMI that have an amount that does not match the transaction in Rock.