### PR TITLE
(SYS-4478) Fixes Expiring Card Email Job

### DIFF
--- a/Rock/Jobs/SendCreditCardExpirationNotices.cs
+++ b/Rock/Jobs/SendCreditCardExpirationNotices.cs
@@ -102,6 +102,7 @@ namespace Rock.Jobs
             foreach ( var transaction in qry )
             {
                 // This checks to see if the expiration is saved in plain text or if it is encrypted. Will return and integer for either case.
+                // NOTE: not necessary if all data is encrypted in the database, may want to revert later
                 if ( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.Length = 2 )
                 {
                   int? expirationMonthDecrypted = transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.AsIntegerOrNull();
@@ -114,7 +115,7 @@ namespace Rock.Jobs
                 } else {
                   int? expirationYearDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationYearEncrypted ).AsIntegerOrNull();
                 }
-                
+
                 if ( expirationMonthDecrypted.HasValue && expirationMonthDecrypted.HasValue )
                 {
                     string acctNum = string.Empty;

--- a/Rock/Jobs/SendCreditCardExpirationNotices.cs
+++ b/Rock/Jobs/SendCreditCardExpirationNotices.cs
@@ -41,7 +41,7 @@ namespace Rock.Jobs
     [DisallowConcurrentExecution]
     public class SendCreditCardExpirationNotices : IJob
     {
-        /// <summary> 
+        /// <summary>
         /// Empty constructor for job initialization
         /// <para>
         /// Jobs require a public empty constructor so that the
@@ -92,7 +92,7 @@ namespace Rock.Jobs
                 && ( t.EndDate == null || t.EndDate > DateTime.Now ) )
                 .AsNoTracking();
 
-            // Get the current month and year 
+            // Get the current month and year
             DateTime now = DateTime.Now;
             int month = now.Month;
             int year = now.Year;
@@ -101,10 +101,22 @@ namespace Rock.Jobs
 
             foreach ( var transaction in qry )
             {
-                int? expirationMonthDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted ).AsIntegerOrNull();
-                int? expirationYearDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationYearEncrypted ).AsIntegerOrNull();
+                // This checks to see if the expiration is saved in plain text or if it is encrypted. Will return and integer for either case.
+                if ( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.Length = 2 )
+                {
+                  int? expirationMonthDecrypted = transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.AsIntegerOrNull();
+                } else {
+                  int? expirationMonthDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted ).AsIntegerOrNull();
+                }
+                if ( transaction.FinancialPaymentDetail.ExpirationYearEncrypted.Length = 2 )
+                {
+                  int? expirationYearDecrypted = transaction.FinancialPaymentDetail.ExpirationYearEncrypted.AsIntegerOrNull();
+                } else {
+                  int? expirationYearDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationYearEncrypted ).AsIntegerOrNull();
+                }
+                
                 if ( expirationMonthDecrypted.HasValue && expirationMonthDecrypted.HasValue )
-                { 
+                {
                     string acctNum = string.Empty;
 
                     if ( !string.IsNullOrEmpty( transaction.FinancialPaymentDetail.AccountNumberMasked ) && transaction.FinancialPaymentDetail.AccountNumberMasked.Length >= 4 )

--- a/Rock/Jobs/SendCreditCardExpirationNotices.cs
+++ b/Rock/Jobs/SendCreditCardExpirationNotices.cs
@@ -103,17 +103,20 @@ namespace Rock.Jobs
             {
                 // This checks to see if the expiration is saved in plain text or if it is encrypted. Will return and integer for either case.
                 // NOTE: not necessary if all data is encrypted in the database, may want to revert later
-                if ( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.Length = 2 )
+                int? expirationMonthDecrypted = null;
+                int? expirationYearDecrypted = null;
+
+                if ( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.Length == 2 )
                 {
-                  int? expirationMonthDecrypted = transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.AsIntegerOrNull();
+                  expirationMonthDecrypted = transaction.FinancialPaymentDetail.ExpirationMonthEncrypted.AsIntegerOrNull();
                 } else {
-                  int? expirationMonthDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted ).AsIntegerOrNull();
+                  expirationMonthDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationMonthEncrypted ).AsIntegerOrNull();
                 }
-                if ( transaction.FinancialPaymentDetail.ExpirationYearEncrypted.Length = 2 )
+                if ( transaction.FinancialPaymentDetail.ExpirationYearEncrypted.Length == 2 )
                 {
-                  int? expirationYearDecrypted = transaction.FinancialPaymentDetail.ExpirationYearEncrypted.AsIntegerOrNull();
+                  expirationYearDecrypted = transaction.FinancialPaymentDetail.ExpirationYearEncrypted.AsIntegerOrNull();
                 } else {
-                  int? expirationYearDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationYearEncrypted ).AsIntegerOrNull();
+                  expirationYearDecrypted = Encryption.DecryptString( transaction.FinancialPaymentDetail.ExpirationYearEncrypted ).AsIntegerOrNull();
                 }
 
                 if ( expirationMonthDecrypted.HasValue && expirationMonthDecrypted.HasValue )


### PR DESCRIPTION
Fixes Issue: [SYS-4478](https://newspring.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=SYS&modal=detail&selectedIssue=SYS-4478)

This fix was two-fold:
1. The expiration dates are stored plain text but were being decrypted anyway, which was returning `null`. Logic was added to say if they are already decrypted, don't attempt to do it again.
2. The algorithm was trying to match our stored two-digit year dates with the built-in JS `Now()` function's four-digit year and was never matching. That has been fixed as well. Out of 344 stored payment methods, seven notices were sent after the fix. An example is posted below.

