### PR TITLE
Add new Rock API endpoints

### DIFF
--- a/Rock.Rest/Controllers/ContentChannelItemsController.Partial.cs
+++ b/Rock.Rest/Controllers/ContentChannelItemsController.Partial.cs
@@ -1,0 +1,76 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.OData;
+
+using Rock.Data;
+using Rock.Model;
+using Rock.Rest.Filters;
+using Rock.Web.Cache;
+
+namespace Rock.Rest.Controllers
+{
+    /// <summary>
+    /// ContentChannelItems REST API
+    /// </summary>
+    public partial class ContentChannelItemsController
+    {
+        #region ContentByDataViewGuids
+        /// <summary>
+        /// Returns a list of content channel items based on a list of dataview guids
+        /// </summary>
+        /// <param name="guids"></param>
+        /// <returns></returns>
+        [HttpGet]
+        [EnableQuery]
+        [Authenticate, Secured]
+        [System.Web.Http.Route( "api/ContentChannelItems/GetFromPersonDataView" )]
+        public IQueryable<ContentChannelItem> GetFromPersonDataView( string guids )
+        {
+            RockContext rockContext = new RockContext();
+
+            // Turn the comma separated list of guids into a list of strings.
+            List<string> guidList = ( guids ?? "" ).Split( ',' ).ToList();
+
+            // Get the Id of the Rock.Model.ContentChannelItem Entity.
+            int contentChannelItemEntityTypeId = EntityTypeCache.Get( "Rock.Model.ContentChannelItem" ).Id;
+
+            // Get the Field Type (Attribute Type) Id of the Data View Field Type.
+            int fieldTypeId = FieldTypeCache.Get( Rock.SystemGuid.FieldType.DATAVIEWS.AsGuid() ).Id;
+
+            // Get the list of attributes that are of the Rock.Model.ContentChannelItem entity type
+            // and that are of the Data View field type.
+            List<int> attributeIdList = new AttributeService( rockContext )
+                .GetByEntityTypeId( contentChannelItemEntityTypeId )
+                .Where( item => item.FieldTypeId == fieldTypeId )
+                .Select( a => a.Id )
+                .ToList();
+
+            // I want a list of content channel items whose ids match up to attribute values that represent entity ids
+            IQueryable<ContentChannelItem> contentChannelItemList = new ContentChannelItemService( rockContext )
+                .Queryable()
+                .WhereAttributeValue( rockContext, av => attributeIdList.Contains( av.AttributeId ) && guidList.Contains( av.Value ) );
+
+            // Return this list
+            return contentChannelItemList;
+        }
+        #endregion
+    }
+}

--- a/Rock.Rest/Controllers/DataViewsController.Partial.cs
+++ b/Rock.Rest/Controllers/DataViewsController.Partial.cs
@@ -1,0 +1,68 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.OData;
+
+using Rock.Data;
+using Rock.Model;
+using Rock.Rest.Filters;
+
+namespace Rock.Rest.Controllers
+{
+    /// <summary>
+    /// DataViews REST API
+    /// </summary>
+    public partial class DataViewsController
+    {
+        #region DataViewByPerson
+
+        /// <summary>
+        /// Returns a list of dataviews that a person is a part of
+        /// </summary>
+        /// <param name="entityTypeId"></param>
+        /// <param name="entityId"></param>
+        /// <param name="categoryGuid"></param>
+        /// <param name="categoryId"></param>
+        /// <returns></returns>
+        [HttpGet]
+        [EnableQuery]
+        [Authenticate, Secured]
+        [System.Web.Http.Route( "api/DataViews/GetPersistedDataViewsForEntity/{entityTypeId}/{entityId}" )]
+        public IQueryable<DataView> GetPersistedDataViewsForEntity( int entityTypeId, int entityId, System.Guid? categoryGuid = null, int categoryId = 0 )
+        {
+            var rockContext = new RockContext();
+            // Get the data view guids from the DataViewPersistedValues table that the Person Id is a part of
+            var persistedValuesQuery = rockContext.DataViewPersistedValues.Where( a => a.EntityId == entityId && a.DataView.EntityTypeId == entityTypeId );
+            IQueryable<DataView> dataViewList = persistedValuesQuery.Select( a => a.DataView );
+            if ( categoryGuid != null )
+            {
+                dataViewList = dataViewList.Where( a => a.Category.Guid == categoryGuid );
+            }
+            if ( categoryId != 0 )
+            {
+                dataViewList = dataViewList.Where( a => a.CategoryId == categoryId );
+            }
+
+            // Return DataView as IQueryable
+            return dataViewList;
+        }
+
+        #endregion
+    }
+}

--- a/Rock.Rest/Controllers/PrayerRequestsController.Parial.cs
+++ b/Rock.Rest/Controllers/PrayerRequestsController.Parial.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 //
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -142,6 +144,59 @@ namespace Rock.Rest.Controllers
             prayerRequest.PrayerCount = ( prayerRequest.PrayerCount ?? 0 ) + 1;
 
             Service.Context.SaveChanges();
+        }
+
+        /// <summary>
+        /// Get the prayer requests of every member of a certain set of groups that a person belongs to
+        /// </summary>
+        /// <param name="groupTypeIds">A list of group type ids</param>
+        /// <param name="personId">The id of the person</param>
+        /// <returns></returns>
+        [Authenticate, Secured]
+        [HttpGet]
+        [System.Web.Http.Route( "api/PrayerRequests/GetByGroups/{personId}" )]
+        public IQueryable<PrayerRequest> GetByGroups( string groupTypeIds, int personId )
+        {
+            RockContext rockContext = new RockContext();
+            System.DateTime now = RockDateTime.Now;
+
+            // Turn the comma separated list of groupTypeIds into a list of strings.
+            List<string> groupTypeIdsList = ( groupTypeIds ?? "" ).Split( ',' ).ToList();
+
+            // Find the groups that the person is a member of.
+            GroupMemberService groupMemberService = new GroupMemberService( rockContext );
+            List<int> personGroupMemberList = groupMemberService.GetByPersonId( personId )
+                .Select( gm => gm.GroupId )
+                .ToList();
+
+            // Filter these groups by the passed in group type ids            
+            GroupService groupService = new GroupService( rockContext );
+            IQueryable<int> groupQueryable = groupService.GetByIds( personGroupMemberList )
+                .AsQueryable()
+                .Where( g => groupTypeIdsList.Contains( g.GroupTypeId.ToString() ) )
+                .Select( g => g.Id );
+
+            // Get all the members of those groups (not including the passed in personId).
+            List<int> groupMemberList = groupMemberService.Queryable()
+                .Where( gm => groupQueryable.Contains( gm.GroupId ) && gm.PersonId != personId ).Select( gm => gm.PersonId ).ToList();
+
+            // Turn the list of PersonIds to PersonAliasIds
+            PersonAliasService personAliasService = new PersonAliasService( rockContext );
+            List<int> groupMemberPersonAliasList = personAliasService.Queryable().Where( pa => groupMemberList.Contains( pa.PersonId ) ).Select( pa => pa.Id ).ToList();
+
+            // Get the prayers for the people.
+            PrayerRequestService prayerRequestService = new PrayerRequestService( rockContext );
+            IQueryable<PrayerRequest> prayerRequestList = prayerRequestService.Queryable()
+                .Where( pr =>
+                    ( groupMemberPersonAliasList.Contains( (int)pr.RequestedByPersonAliasId ) ) &&
+                    ( pr.IsActive.HasValue && pr.IsActive.Value == true ) &&
+                    ( pr.IsPublic.HasValue && pr.IsPublic.Value == true ) &&
+                    ( pr.IsApproved.HasValue && pr.IsApproved == true ) &&
+                    ( !pr.ExpirationDate.HasValue || pr.ExpirationDate.Value > now )
+                );
+
+            //Return this as a queryable.
+            return prayerRequestList;
         }
     }
 }

--- a/Rock.Rest/Rock.Rest.csproj
+++ b/Rock.Rest/Rock.Rest.csproj
@@ -127,7 +127,9 @@
     <Compile Include="Controllers\CodeGenerated\NcoaHistoriesController.cs" />
     <Compile Include="Controllers\CodeGenerated\PageShortLinksController.cs" />
     <Compile Include="Controllers\CodeGenerated\PersonTokensController.cs" />
+    <Compile Include="Controllers\ContentChannelItemsController.Partial.cs" />
     <Compile Include="Controllers\ContentChannelItemSlugsController.Partial.cs" />
+    <Compile Include="Controllers\DataViewsController.Partial.cs" />
     <Compile Include="Controllers\FinancialGatewaysController.Partial.cs" />
     <Compile Include="Controllers\GroupMemberHistoricalsController.Partial.cs" />
     <Compile Include="Controllers\NotesController.Partial.cs" />


### PR DESCRIPTION
This adds three new API endpoints to our Rock instance:
+ GET Content Channel Items by a list of data view guids
+ GET Persisted Data Views by entity type & entity id. Can also filter by category or category Id.
+ GET Prayer Requests for group members in your groups filtered by group type and person Id.