### PR TITLE
Added Android applinks file

### DIFF
--- a/RockWeb/.well-known/applinks.json
+++ b/RockWeb/.well-known/applinks.json
@@ -1,0 +1,9 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.newspring.newspringapp"
+    }
+  }
+]


### PR DESCRIPTION
This PR adds the applinks.json file to the root of the RockWeb in the .well-known folder so that links opened on android can be correctly directed to the app.