### PR TITLE
Updated locations pages files to support middle/high school fuse service times & locations

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
@@ -9,12 +9,31 @@
     
     {% for service in servicesJSON %}
         {% if service.ServiceType == servicetype %}
-            {{ service.ServiceDay }} {{ service.ServiceTime | Remove:':00' | Remove:' ' | Downcase }}<br>
-            {% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}<span class="text-gray-light">Doors Open at {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}</span><br>{% endif %}
-            {% if service.PickUpTime and service.PickUpTime != empty %}<span class="text-gray-light">Pick Up Students at {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}</span><br>{% endif %}
+            {% if service.ServiceLabel != empty %}<strong>{{ service.ServiceLabel }}</strong> {% if service.DoorsOpenTime != empty or service.PickUpTime != empty %}<i class="fa fa-info-circle text-info " style="margin-top: 3px;" data-toggle="tooltip" data-placement="top" title="{% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}Doors Open - {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.PickUpTime and service.PickUpTime != empty %}Pick Up Students - {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %}"></i>{% endif %}<br>{% endif %}
+            {{ service.ServiceDay }} {{ service.ServiceTime | Remove:':00' | Remove:' ' | Downcase }} {% if service.ServiceLabel == '' and service.DoorsOpenTime != empty or service.PickUpTime != empty %}<i class="fa fa-info-circle text-info " style="margin-top: 3px;" data-toggle="tooltip" data-placement="top" title="{% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}Doors Open - {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.PickUpTime and service.PickUpTime != empty %}Pick Up Students - {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %}"></i>{% endif %}
+            {% if service.ServiceLocation.Street1 != empty %}
+                {% capture serviceLocationAddress %}{{ service.ServiceLocation.Street1 }} {% if service.ServiceLocation.Street2 != empty %}{{ service.ServiceLocation.Street2 }} {% endif %}{{ service.ServiceLocation.City }} {{ service.ServiceLocation.State }} {{ service.ServiceLocation.PostalCode }}{% endcapture %}
+                {% assign getDirections = 'https://www.google.com/maps/place/' | Append:serviceLocationAddress | Replace:" ","+" %}
+            {% else %}
+                {% if servicetype == 'Fuse' %}
+                    {% assign getDirections = campus | Attribute:'FuseGetDirectionsURL','RawValue' %}
+                {% else %}
+                    {% assign getDirections = campus | Attribute:'GetDirectionsURL','RawValue' %}
+                {% endif %}
+            {% endif %}
+            {% if servicetype == 'Fuse' %}
+                <br><a href="{{ getDirections }}" target="_blank">Get Directions</a>
+                <br>
+            {% endif %}
+            <br>
             {% assign serviceDay = service.ServiceDay %}
         {% endif %}
     {% endfor %}
+
+    {% if servicetype == 'NewSpring' %}
+    <br><a href="{{ getDirections }}" target="_blank">Get Directions</a>
+    {% endif %}
+
     {% assign serviceDay = '' %}
 
 {% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -11,7 +11,16 @@
 {% capture id %}{% endcapture %}
 {% capture title %}{{ campus.Name }}, SC{% endcapture %}
 {% capture titlesize %}{% endcapture %}
-{% capture content %}<p class="lead">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>{% endcapture %}
+{% capture content %}
+    {% if servicetype == 'NewSpring' %}
+    <p class="lead">{{ campus.Location.Street1 }}
+        {% if campus.Location.Street2 != '' %}
+        <br>{{ campus.Location.Street2 }}
+        {% endif %}
+        <br>{{ campus.Location.City }}, {{ campus.Location.State }} {{ campus.Location.PostalCode }}
+    </p>
+    {% endif %}
+{% endcapture %}
 {% capture textalignment %}{% endcapture %}
 {% capture label %}{% endcapture %}
 {% capture subtitle %}{% endcapture %}
@@ -29,9 +38,16 @@
 {% capture trimcopy %}{% endcapture %}
 {% capture linkcolor %}{% endcapture %}
 {% capture backgroundcolor %}#303030{% endcapture %}
-{% capture linkurl %}{% if servicetype == 'Fuse' and fuseDirectionsUrl and fuseDirectionsUrl != empty %}{{ fuseDirectionsUrl }}{% else %}{{ nsDirectionsUrl }}{% endif %}{% endcapture %}
-{% capture linktext %}Get Directions{% endcapture %}
-{% capture linktarget %}_blank{% endcapture %}
+
+{% if servicetype == 'NewSpring' %}
+    {% capture linkurl %}{% if servicetype == 'Fuse' and fuseDirectionsUrl and fuseDirectionsUrl != empty %}{{ fuseDirectionsUrl }}{% else %}{{ nsDirectionsUrl }}{% endif %}{% endcapture %}
+    {% capture linktext %}Get Directions{% endcapture %}
+    {% capture linktarget %}_blank{% endcapture %}
+{% else %}
+    {% assign linkurl = "" %}
+    {% assign linktext = "" %}
+{% endif %}
+
 {% capture hideforegroundelements %}{% endcapture %}
 
 {[ hero id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' ]}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -6,12 +6,10 @@
 
 <div class="row text-center">
     <div class="col-xs-12 col-sm-12 col-md-4">
-        <h3 class="push-half-bottom">Address</h3>
-        <p class="lead">{{ campus.Location.Street1 }}
-        {% if campus.Location.Street2 != '' %}
-        <br>{{ campus.Location.Street2 }}
-        {% endif %}
-        <br>{{ campus.Location.City }}, {{ campus.Location.State }} {{ campus.Location.PostalCode }}</p>
+        <h3 class="push-half-bottom">Service Times</h3>
+        <p class="lead">
+        {[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}
+        </p>
     </div><div class="col-xs-12 col-sm-12 col-md-4">
         <h3 class="push-half-bottom">Phone</h3>
         <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -31,8 +31,15 @@
     {% capture trimcopy %}{% endcapture %}
     {% capture linkcolor %}{% endcapture %}
     {% capture backgroundcolor %}{% endcapture %}
-    {% capture linkurl %}/staff/campus/{{ campus.Name | Replace:' ','-' | Downcase }}{% endcapture %}
-    {% capture linktext %}More {{ campus.Name }} Staff{% endcapture %}
+
+    {% if servicetype == 'Fuse' %}
+        {% capture linkurl %}mailto:{{ cp | Attribute:'StaffEmail' }}{% endcapture %}
+        {% capture linktext %}Contact {{ cp.NickName }}{% endcapture %}
+    {% else %}
+        {% capture linkurl %}/staff/campus/{{ campus.Name | Replace:' ','-' | Downcase }}{% endcapture %}
+        {% capture linktext %}More {{ campus.Name }} Staff{% endcapture %}
+    {% endif %}
+    
     {% capture hideforegroundelements %}{% endcapture %}
 
     {[ sideBySide id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' ]}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
@@ -14,12 +14,9 @@
 
                 {% capture content %}
                     <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
-                    {% if directionsURL and directionsURL != empty %}
-                        <p><a href="{% if fuseDirectionsUrl and fuseDirectionsUrl != empty and servicetype == 'Fuse' %}{{ fuseDirectionsUrl }}{% else %}{{ directionsURL }}{% endif %}" target="_blank">Get Directions</a></p>
-                    {% endif %}
                 {% endcapture %}
             
-                {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
+                {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
                 
             [[ enditem ]]
         {% endfor %}


### PR DESCRIPTION
## DESCRIPTION

This PR includes changes to our lava templates to support two new matrix template attributes - `Service Label` which will be used for designating middle/high school fuse services and `Service Location` which will be used for specifying a meeting location for a specific service when the service is happening at a location that differs from the campus' normal NewSpring/Fuse meeting locations.

### Visual Changes
![IMG_CB1352EDF472-1](https://user-images.githubusercontent.com/2465823/63288458-c18c8d00-c28a-11e9-890b-50493a5309c4.jpeg)
![IMG_67C391AA47AE-1](https://user-images.githubusercontent.com/2465823/63288465-c5201400-c28a-11e9-8d08-cf97f37985de.jpeg)
![IMG_DA6D0CAB3103-1](https://user-images.githubusercontent.com/2465823/63288470-c81b0480-c28a-11e9-9638-d2087ac22373.jpeg)
![IMG_00D5E64942F9-1](https://user-images.githubusercontent.com/2465823/63288477-cb15f500-c28a-11e9-8c2d-ce89ad29b8cb.jpeg)

### How do I test this PR?

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
