### PR TITLE
Fix for Content Channel Items w/Multiple Parent Items

### DIFF
--- a/RockWeb/Themes/NewSpring/Layouts/Site.Master
+++ b/RockWeb/Themes/NewSpring/Layouts/Site.Master
@@ -110,7 +110,7 @@
                 <Rock:Lava ID="PageTitle" runat="server">
                     {% if CurrentPage.PageDisplayTitle == 'True' %}
                         <div class="{% if CurrentPage.MenuDisplayChildPages == 'True' %}hidden-md hidden-lg{% endif %}">
-                            {[ pageHeader title:'{{ 'Global' | Page:'Title' }}' ]}
+                            {[ pageHeader title:'{{ 'Global' | Page:'Title' | Replace:"'","’" }}' ]}
                         </div>
                     {% endif %}         
                 </Rock:Lava>

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -25,10 +25,11 @@
 {% capture parentids %}{% for parent in Item.ParentItems %}{{ parent.ContentChannelItemId }}{% if forloop.last != True %},{% endif %}{% endfor %}{% endcapture %}
 
 {%- comment -%}If this item has parents, get the one from the primary content channel and then set variables for use later{%- endcomment -%}
-{% if parentCount > 0 %}
+{% if parentCount > 0 and parentccid and parentccid != empty %}
     {% contentchannelitem ids:'{{ parentids }}' where:'ContentChannelId == "{{ parentccid }}"' iterator:'parents' %}
         {% for parent in parents %}
             {% assign parentTitle = parent.Title %}
+            {% capture parentPermalink %}{[ getPermalink cciid:'{{ parent.Id }}' ]}{% endcapture %}
             {% assign parentImage = parent | Attribute:'ImageLandscape','Url' %}
             {% assign baseBackgroundColor = parent | Attribute:'BackgroundColor' %}
             {% if baseBackgroundColor and baseBackgroundColor != empty %}
@@ -94,11 +95,8 @@
             
             <h1 class="h2 xs-h3 push-half-top push-bottom xs-push-half-bottom">{{ Item.Title }}</h1>
 
-            {% capture collectiontext %}{[ getParentTitleFromChildId id:'{{ Item.Id }}' ]}{% endcapture %}
-            {% assign collectiontext = collectiontext | Trim %}
-            {% capture collectionurl %}{[ getPermalink cciid:'{{ Item.Id }}' ]}{% endcapture %}
-            {% if collectiontext and collectiontext != empty %}
-                <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if collectionurl != empty %}<a href="{{ collectionurl }}">{% endif %}{{ collectiontext }}{% if collectionurl != empty %}</a>{% endif %}</small>
+            {% if parentTitle and parentTitle != empty %}
+                <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentTitle }}{% if parentPermalink != empty %}</a>{% endif %}</small>
             {% endif %}
             
             {% if subtitle != empty %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/page-header.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/page-header.lava
@@ -4,7 +4,7 @@
         <p class="hidden sans-serif stronger letter-spacing-condensed push-half-bottom xs-push-bottom">{{ blockData.preTitle | safe }}</p>
     {% endif %}
 
-    <h1 class="h4 xs-h6 stronger flush">{{ title }}</h1>
+    <h1 class="h4 xs-h6 stronger flush">{{ title | Replace:"'","’" }}</h1>
 
     {% if subtitle != '' %}
         <p class="hidden sans-serif stronger letter-spacing-condensed push-half-top flush-bottom {% if pageHeaderColorHex %}{% else %}text-gray-dark{% endif %}"><small>{{ blockData.subtitle | safe }}</small></p>


### PR DESCRIPTION
@richarddubay this is the follow up to the previous PR for this. I updated the `editorial-detail` template to check for a value in the item's primary channel attribute.

I also stumbled across another bug with page titles with apostrophes where the rest of the page title would be cut off after the apostrophe, and fixed that as well.

https://newspring.cc/fuse/sermons/lets-talk-about-it/lets-talk-about-it-connection-racism-and-qa

![image](https://user-images.githubusercontent.com/2465823/64284479-b17dda00-cf27-11e9-9239-b34588ace40e.png)

For testing, you can see which content channel items I've added to the campaign [here.](https://brian-rock.newspring.cc/page/342?contentItemId=11382) You should be able to check their corresponding pages and everything _should_ be 💯.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
