### PR TITLE
Updates to editorial and collection detail layouts to fix issues with devo navigation

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
@@ -43,13 +43,21 @@
     {% capture textalignment %}{% endcapture %}
     {% capture type %}{% endcapture %}
     {% capture label %}{{ type }}{% endcapture %}
-    {% assign dates = Item | Attribute:'Dates','RawValue' %}
-    {% assign dateparts = dates | Split:',' %}
-    {% assign datePart1 = dateparts[0] | Date:'yyyyMMdd' %}
-    {% assign datePart2 = dateparts[1] | Date:'yyyyMMdd' %}
-    {% if dates != empty %}
-        {% capture subtitle %}{[ formatDate date:'{{ dateparts[0] }}' ]}{% if datePart1 != datePart2 %} - {[ formatDate date:'{{ dateparts[1] }}' ]}{% endif %}{% endcapture %}
+    
+    {% assign isDateVisible = Item.ContentChannel | Attribute:'IsDateVisible','RawValue' %}
+    {% if isDateVisible == 'True' %}
+        {% assign dates = Item | Attribute:'Dates','RawValue' %}
+        {% assign dateParts = dates | Split:',' %}
+        {% assign datePartsSize = dateParts | Size %}
+        {% assign datePart1 = dateParts[0] | Date:'yyyyMMdd' %}
+        {% if datePartsSize > 1 %}
+            {% assign datePart2 = dateParts[1] | Date:'yyyyMMdd' %}
+        {% endif %}
+        {% if dates != empty %}
+            {% capture subtitle %}{[ formatDate date:'{{ dateParts[0] }}' ]}{% if datePartsSize > 1 and datePart1 != datePart2 %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}{% endcapture %}
+        {% endif %}
     {% endif %}
+
     {% capture imageurl %}{{ Item | Attribute:'ImageSquare','Url' }}{% endcapture %}
     {% capture imageoverlayurl %}{% endcapture %}
     {% capture imagealignment %}Left{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -33,7 +33,7 @@
 
             {% capture childrenPermalinks %}[
                     {% for child in parent.ChildItems %}{
-                        "order": "{{ child.ChildContentChannelItem.Order }}",
+                        "order": "{{ child.ChildContentChannelItem.Order | DividedBy:10 }}",
                         "url": "{[ getPermalink cciid:'{{ child.ChildContentChannelItem.Id }}' ]}"
 
                         {% if child.ChildContentChannelItem.Title == Item.Title %}
@@ -42,6 +42,8 @@
                     }{% if forloop.last != true %},{% endif %}{% endfor %}
             ]{% endcapture %}
             {% assign childrenPermalinks = childrenPermalinks | Trim | FromJSON %}
+
+            {% assign childrenPermalinks = childrenPermalinks | OrderBy:'order' %}
 
             {% assign parentTitle = parent.Title %}
             {% capture parentPermalink %}{[ getPermalink cciid:'{{ parent.Id }}' ]}{% endcapture %}
@@ -173,6 +175,8 @@
             {% if itemIndex and itemIndex != empty %}
                 {% assign prevLinkIndex = itemIndex | Minus:2 %}
                 {% assign nextLinkIndex = itemIndex %}
+
+
                 <div class="row flush">
                     <div class="col-xs-4 col-sm-4 col-md-4 hard">
                         {% if itemIndex and itemIndex != 1 %}<a href="{{ childrenPermalinks | Index:prevLinkIndex | Property:'url' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom"><i class="fas fa-angle-left"></i> Prev</a>{% endif %}


### PR DESCRIPTION
## DESCRIPTION

The included changes are follow-ups to the devotional navigation feature we added in our latest deploy.

- Update collection detail layout to not show dates if the channel that is being shown has date visible attribute set to false.

- Updated editorial detail layout to order the `childrenPermalinks` object correctly so when we pull next/previous links by index, the correct url is used.

## TESTING
- [x] Study/Series pages should no longer show the date if their channel attribute for `IsDateVisible` is set to `false`.
- [x] Devotional next/prev links should now accurately link to the next/prev devotional - being consistent with the next/prev devotionals in the child items swiper on the bottom of every devotional page.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
