### PR TITLE
Fix Transaction Block Cherry Pick

### DIFF
--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx
@@ -73,9 +73,9 @@
                     <div class="row">
                         <div class="col-md-6">
                             <Rock:DefinedValuePicker ID="dvpTransactionType" runat="server" Label="Transaction Type" Required="true" />
-                            <Rock:DefinedValuePicker ID="dvpNonCashAssetType" runat="server" Label="Non-Cash Asset Type" />
                             <Rock:DefinedValuePicker ID="dvpSourceType" runat="server" Label="Source" />
                             <Rock:DefinedValuePicker ID="dvpCurrencyType" runat="server" Label="Currency Type" AutoPostBack="true" OnSelectedIndexChanged="ddlCurrencyType_SelectedIndexChanged" Required="true" />
+                            <Rock:DefinedValuePicker ID="dvpNonCashAssetType" runat="server" Label="Non-Cash Asset Type" />
                             <Rock:DefinedValuePicker ID="dvpCreditCardType" runat="server" Label="Credit Card Type" />
                             <Rock:DynamicPlaceholder ID="phPaymentAttributeEdits" runat="server" />
                             <Rock:FinancialGatewayPicker ID="gpPaymentGateway" runat="server" Label="Payment Gateway" ShowAll="true" />

--- a/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
+++ b/RockWeb/Blocks/Finance/TransactionDetail.ascx.cs
@@ -1226,6 +1226,11 @@ namespace RockWeb.Blocks.Finance
             }
 
             var nonCashCurrencyType = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.CURRENCY_TYPE_NONCASH );
+            if ( nonCashCurrencyType == null )
+            {
+                return false;
+            }
+
             return ( CurrencyTypeId == nonCashCurrencyType.Id );
         }
 
@@ -1752,7 +1757,7 @@ namespace RockWeb.Blocks.Finance
         private void SetNonCashAssetTypeVisibility()
         {
             int? currencyType = dvpCurrencyType.SelectedValueAsInt();
-            dvpCreditCardType.Visible = IsNonCashTransaction( currencyType );
+            dvpNonCashAssetType.Visible = IsNonCashTransaction( currencyType );
         }
 
         /// <summary>


### PR DESCRIPTION
+ Fixed error on the TransactionDetail block when selecting a currency type if the "Non-Cash" currency type was missing. (Fixes #3894)