### PR TITLE
Fix Prayer API

### DIFF
--- a/Rock.Rest/Controllers/PrayerRequestsController.Partial.cs
+++ b/Rock.Rest/Controllers/PrayerRequestsController.Partial.cs
@@ -165,14 +165,14 @@ namespace Rock.Rest.Controllers
 
             GroupMemberService groupMemberService = new GroupMemberService( rockContext );
 
-            IQueryable<int> groupMemberPersonAliasList = groupMemberService.GetByPersonId( personId )   // Get the groups that a person is a part of
-                .Where( gm =>
-                    groupTypeIdsList.Contains( gm.Group.GroupTypeId ) &&    // Filter those groups by a set of passed in group types. 
-                    gm.Group.IsActive == true && gm.Group.IsArchived == false   // Also make sure the groups are active and not archived.
+            IQueryable<int> groupMemberPersonAliasList = groupMemberService.GetByPersonId(personId)   // Get the groups that a person is a part of
+                .Where(gm =>
+                   groupTypeIdsList.Contains(gm.Group.GroupTypeId) &&    // Filter those groups by a set of passed in group types. 
+                   gm.Group.IsActive == true && gm.Group.IsArchived == false   // Also make sure the groups are active and not archived.
                  )
-                .SelectMany( gm => gm.Group.Members )   // Get the members of those groups
-                .Where( gm => gm.GroupMemberStatus == GroupMemberStatus.Active && gm.IsArchived == false ) // Make sure that the group members are active and haven't been archived
-                .Select( m => m.Person.Aliases.FirstOrDefault().Id );   // Return the person alias ids
+                .SelectMany(gm => gm.Group.Members)   // Get the members of those groups
+                .Where(gm => gm.GroupMemberStatus == GroupMemberStatus.Active && gm.IsArchived == false) // Make sure that the group members are active and haven't been archived
+                .SelectMany( m => m.Person.Aliases).Select( a => a.Id);  // Return the all the person alias ids of the group members
 
             // Get the prayers for the people.
             PrayerRequestService prayerRequestService = new PrayerRequestService( rockContext );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the prayer request API call to get all the person alias id's for a person instead of just one when pulling prayers for a person's groups.

### How do I test this PR?
Here is what I did to test:
* Running Rock locally, I added myself to Frank's homebrew group as an active member
* Added a prayer from Isaac.
* Ran the API request using my person id and the group types 10, 23, 25, 60, 141.
* I saw both Frank's and Isaac's prayer requests in the returned data.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
