### PR TITLE
Reverted site.master changes that causes links to open in a new window

### DIFF
--- a/RockWeb/Themes/NewSpring/Layouts/Site.Master
+++ b/RockWeb/Themes/NewSpring/Layouts/Site.Master
@@ -176,20 +176,6 @@
                     </ProgressTemplate>
             </asp:UpdateProgress>
 
-            <script>
-                $('a').each(function() {
-                    var a = new RegExp('/' + window.location.host + '/');
-
-                    if(!a.test(this.href) && this.getAttribute('onclick') == null) {
-                        $(this).click(function(event) {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            window.open(this.href, '_blank');
-                        });
-                    }
-                });
-            </script>
-
         </form>
 
     </body>


### PR DESCRIPTION
## DESCRIPTION

Reverted site.master changes that causes links to open in a new window

### How do I test this PR?

Links should go to where you expect them to, and not open in a new tab unless a `target` attribute exists on the anchor with a value of `_blank`. You should be able to edit block content/settings without issue.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
