### PR TITLE
Updated child item swiper lava to reference the order property in content channel item association table as those values were moved from the content channel item table

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -1,4 +1,6 @@
-<!-- Redirect to 404 if Entry is Expired -->
+{% comment %}
+    Redirect to 404 if Entry is Expired
+{% endcomment %}
 {% assign pageId = 'Global' | Page:'Id' %}
 {% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
 {% assign currentTime = 'Now' | Date:'yyyyMMddHHmm' %}
@@ -11,65 +13,61 @@
     {% endif %}
 {% endif %}
 
-{%- comment -%}Get number of parent items{%- endcomment -%}
-{% assign parentCount = Item.ParentItems | Size %}
-
-{%- comment -%}Get Id of primary parent channel attribute so we know which item to pull image/slug from when there are more than one parent{%- endcomment -%}
-{% contentchannel id:'{{ Item.ContentChannelId }}' iterator:'channels' %}
-    {% for channel in channels %}
-        {% assign parentccid = channel | Attribute:'PrimaryParentChannel','Object' | Property:'Id' %}
-    {% endfor %}
-{% endcontentchannel %}
-
-{%- comment -%}Get Ids of parent items for this item{%- endcomment -%}
-{% assign parentids = Item.ParentItems | Select:'ContentChannelItemId' | Join:',' %}
-{% assign itemIndex = '' %}
-
-{%- comment -%}If this item has parents, get the one from the primary content channel and then set variables for use later{%- endcomment -%}
-{% if parentCount > 0 and parentccid and parentccid != empty %}
-    {% contentchannelitem ids:'{{ parentids }}' where:'ContentChannelId == "{{ parentccid }}"' iterator:'parents' %}
-        {% for parent in parents %}
-            {% assign totalChildren = parent.ChildItems | Size %}
-
-            {% capture childrenPermalinks %}[
-                    {% for child in parent.ChildItems %}{
-                        "order": "{{ child.ChildContentChannelItem.Order | DividedBy:10 }}",
-                        "url": "{[ getPermalink cciid:'{{ child.ChildContentChannelItem.Id }}' ]}"
-
-                        {% if child.ChildContentChannelItem.Title == Item.Title %}
-                            {% assign itemIndex = child.ChildContentChannelItem.Order | Plus:1 %}
-                        {% endif %}
-                    }{% if forloop.last != true %},{% endif %}{% endfor %}
-            ]{% endcapture %}
-            {% assign childrenPermalinks = childrenPermalinks | Trim | FromJSON %}
-
-            {% assign childrenPermalinks = childrenPermalinks | OrderBy:'order' %}
-
-            {% assign parentTitle = parent.Title %}
-            {% capture parentPermalink %}{[ getPermalink cciid:'{{ parent.Id }}' ]}{% endcapture %}
-            {% assign parentImage = parent | Attribute:'ImageLandscape','Url' %}
-            {% assign baseBackgroundColor = parent | Attribute:'BackgroundColor' %}
-            
-        {% endfor %}
-    {% endcontentchannelitem %}
-{% endif %}
-
-{% if baseBackgroundColor and baseBackgroundColor != empty %}
-    {% assign backgroundColor = baseBackgroundColor %}
-    <style>
-        .brand-bg {
-            background-color: {{ backgroundColor | Darken:'10%' }};
-        }
-    </style>
-{% endif %}
-
+{% comment %}
+    Set current item slug so we can determine what the active slide should be
+{% endcomment %}
+{% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
 {% assign label = '' %}
-{% if itemIndex and itemIndex != empty %}
-    {% capture label %}Session {{ itemIndex }}{% endcapture %}
+
+{% comment %}
+    Set item properties/attributes
+{% endcomment %}
+{% assign itemImage = Item | Attribute:'ImageLandscape','Url' %}
+{% assign summary = Item | Attribute:'Summary' %}
+{% assign video = Item | Attribute:'Video','RawValue' %}
+{% assign isDateVisible = Item.ContentChannel | Attribute:'IsDateVisible','RawValue' %}
+{% capture date %}{[ formatDate date:'{{ Item.StartDateTime }}' ]}{% endcapture %}
+{% capture tags %}{[ tags guid:'{{ Item.Guid }}']}{% endcapture %}
+{% assign tags = tags | Trim %}
+
+{% comment %}
+    Set parent properties/attributes
+{% endcomment %}
+{% assign primaryParentChannelId = Item.ContentChannel | Attribute:'PrimaryParentChannel','Id' %}
+{% assign parentItem = Item.ParentItems | Select:'ContentChannelItem' | Where:'ContentChannelId', primaryParentChannelId | First %}
+{% assign parentImage = parentItem | Attribute:'ImageLandscape','Url' %}
+{% assign itemsManuallyOrdered = parentItem.ContentChannel.ChildItemsManuallyOrdered %}
+{% capture parentPermalink %}{[ getPermalink cciid:'{{ parentItem.Id }}' ]}{% endcapture %}
+{% assign totalChildren = parentItem.ChildItems | Size %}
+
+{% if itemsManuallyOrdered == 'true' %}
+    {% sql %}
+        SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) 'Index', cci.Id, ccis.Slug
+        FROM ContentChannelItemAssociation ccia
+        JOIN ContentChannelItem cci
+        ON ccia.ChildContentChannelItemId = cci.Id
+        JOIN ContentChannelItemSlug ccis
+        ON ccis.ContentChannelItemId = cci.Id
+        WHERE ccia.ContentChannelItemId = '{{ parentItem.Id }}'
+        ORDER BY ccia.[Order]
+    {% endsql %}
+    {% assign itemIndex = results | Where:'Slug', currentSlug | Select:'Index' | First %}
+    {% assign prevIndex = itemIndex | Minus:2 %}
+    {% assign nextIndex = itemIndex %}
+
+    {% if itemIndex and itemIndex != empty %}
+        {% capture label %}Session {{ itemIndex }}{% endcapture %}
+    {% endif %}
 {% endif %}
 
+{% comment %}
+    Set image url
+{% endcomment %}
+{% capture imageUrl %}{% if itemImage != empty %}{{ itemImage }}{% elseif parentImage != empty %}{{ parentImage }}{% endif %}{% endcapture %}
 
-<!-- Set Page/Browser Titles -->
+{% comment %}
+    Set page/browser titles
+{% endcomment %}
 {% assign pagePath = 'Global' | Page:'Path' %}
 {% assign orgName = 'Global' | Attribute:'OrganizationName' %}
 {% assign channelNameParts = Item.ContentChannel.Name | Split:' - ' %}
@@ -79,28 +77,21 @@
 {{ browserTitle | SetPageTitle:'BrowserTitle' }}
 {{ channelName | Singularize | SetPageTitle:'PageTitle' }}
 
+{% comment %}
+    Set page background color from parent attribute
+{% endcomment %}
+{% assign parentBackgroundColor = parentItem | Attribute:'BackgroundColor' %}
+{% if parentBackgroundColor != empty %}
+    <style>
+        .brand-bg {
+            background-color: {{ parentBackgroundColor }};
+        }
+    </style>
+{% endif %}
 
 
 {% assign defaultTranslation = 'Global' | Attribute:'BibleTranslation','Value' %}
 {[ scripturize defaulttranslation:'{{ defaultTranslation }}' landingsite:'YouVersion' cssclass:'scripture' openintab:'true' ]}
-
-    {% capture type %}{% assign typeParts = Item.ContentChannel.Name | Split:' - ' %}{{ typeParts[1] }}{% endcapture %}
-    {% assign cciid = Item.Id %}
-    {% assign subtitle = Item | Attribute:'Subtitle' %}
-    {% assign summary = Item | Attribute:'Summary' %}
-    {% assign video = Item | Attribute:'Video','RawValue' %}
-    {% capture date %}{[ formatDate date:'{{ Item.StartDateTime }}' ]}{% endcapture %}
-    {% assign itemimageurl = Item | Attribute:'ImageLandscape','Url' %}
-
-    {% capture imageurl %}
-        {% if itemimageurl and itemimageurl != empty %}
-            {{ itemimageurl }}
-        {% elseif Item.ParentItems %}
-            {{ parentImage }}
-        {% endif %}
-    {% endcapture %}
-    {% assign imageurl = imageurl | Trim %}
-
 
     <div class="md-text-constrained md-mx-auto panel overflow-hidden">
         <div class="editorial-content position-relative panel-body bg-white xs-soft xs-soft-half-bottom">
@@ -119,8 +110,8 @@
             
             <h1 class="h2 xs-h3 push-half-bottom xs-push-half-bottom">{{ Item.Title }}</h1>
 
-            {% if parentTitle and parentTitle != empty %}
-                <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentTitle }}{% if parentPermalink != empty %}</a>{% endif %}</small>
+            {% if parentItem and parentItem != empty %}
+                <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentItem.Title }}{% if parentPermalink != empty %}</a>{% endif %}</small>
             {% endif %}
             
             {% if subtitle != empty %}
@@ -133,8 +124,8 @@
                 <p class="stronger">{{ communicatorNames | Trim }}</p>
             {% endif %}
             
-            {% if imageurl and imageurl != empty %}
-                <div class="ratio-landscape background-cover push-bottom rounded" style="background-image:url('{{ imageurl }}');"></div>
+            {% if imageUrl and imageUrl != empty %}
+                <div class="ratio-landscape background-cover push-bottom rounded" style="background-image:url('{{ imageUrl }}');"></div>
             {% endif %}
 
             {% assign scripturesguid = Item | Attribute:'Scriptures','RawValue' %}
@@ -172,21 +163,29 @@
                 </div>
             </div>
 
-            {% if itemIndex and itemIndex != empty %}
-                {% assign prevLinkIndex = itemIndex | Minus:2 %}
-                {% assign nextLinkIndex = itemIndex %}
 
 
+
+
+            {%- comment -%}
+                Entry navigation
+            {%- endcomment -%}
+            {% if itemsManuallyOrdered == 'true' %}
                 <div class="row flush">
                     <div class="col-xs-4 col-sm-4 col-md-4 hard">
-                        {% if itemIndex and itemIndex != 1 %}<a href="{{ childrenPermalinks | Index:prevLinkIndex | Property:'url' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom"><i class="fas fa-angle-left"></i> Prev</a>{% endif %}
+                        {% if itemIndex and itemIndex != 1 %}<a href="{{ results | Index:prevIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom"><i class="fas fa-angle-left"></i> Prev</a>{% endif %}
                     </div><div class="col-xs-4 col-sm-4 col-md-4 text-center hard">
                         <p class="text-gray-light flush"><i>{{ itemIndex }} of {{ totalChildren }}</i></p>
                     </div><div class="col-xs-4 col-sm-4 col-md-4 text-right hard">
-                        {% if itemIndex and itemIndex != totalChildren %}<a href="{{ childrenPermalinks | Index:nextLinkIndex | Property:'url' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom">Next <i class="fas fa-angle-right"></i></a>{% endif %}
+                        {% if itemIndex and itemIndex != totalChildren %}<a href="{{ results | Index:nextIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom">Next <i class="fas fa-angle-right"></i></a>{% endif %}
                     </div>
                 </div>
             {% endif %}
+
+
+
+
+
             
             {% capture itemToken %}cci{{ Item.ContentChannelId }}{{ Item.Id }}{% endcapture %}
             {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
@@ -194,7 +193,6 @@
             {% assign shareimageurl = imageurl %}
             {% assign shareauthor = 'newspring' %}
             {% assign sharetitle = Item.Title %}
-            {% assign summary = Item | Attribute:'Summary' %}
             {%- capture sharesummary -%}
                 {% if summary and summary != empty %}
                     {{ summary | StripHtml | HtmlDecode | Truncate:150,'...' }}
@@ -206,17 +204,6 @@
 
             
             {[ modalShare ]}
-            {% capture tags %}{[ tags guid:'{{ Item.Guid }}']}{% endcapture %}
-            {% assign tags = tags | Trim %}
-
-            {% capture isDateVisible %}
-                {% contentchannel where:'Id == "{{ Item.ContentChannel.Id }}"' iterator:'channels' %}
-                    {% for channel in channels %}
-                        {{ channel | Attribute:'IsDateVisible','RawValue' }}
-                    {% endfor %}
-                {% endcontentchannel %}
-            {% endcapture %}
-            {% assign isDateVisible = isDateVisible | Trim %}
             
             {% if isDateVisible == 'True' %}
                 {% if tags and tags != empty %}
@@ -248,65 +235,3 @@
     </div>
 
 {[ endscripturize ]}
-
-<!-- Structured Data -->
-{% capture tagsData %}{[ tagData guid:'{{ Item.Guid }}' ]}{% endcapture %}
-{% assign tagsData = tagsData | Trim %}
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "Article",
-  "publisher": {
-    "@type": "Organization",
-    "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://newspring.cc/GetImage.ashx?id=661329"
-    }
-  },
-  "author": "{% if communicatorNames and communicatorNames != empty and communicatorNames != '' %}{{ communicatorNames | Trim }}{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}",
-  {% if tagsData and tagsData != empty %}
-    "keywords": "{{ tagsData }}",
-  {% endif %}
-  "headline": "{{ Item.Title | Escape }}",
-  {% if summary and summary != empty %}
-    "description": "{{ summary | StripHtml | Escape }}",
-  {% endif %}
-  "articleBody": "{{ Item.Content | StripHtml | Escape }}",
-  {% if subtitle and subtitle != empty %}
-    "alternativeHeadline": "{{ subtitle }}",
-  {% endif %}
-
-  {% if isDateVisible == 'True' %}
-  "datePublished": "{{ Item.StartDateTime }}",
-  "dateModified": "{{ Item.ModifiedDateTime }}",
-    {% if Item.ExpireDateTime %}
-    "expires": "{{ Item.ExpireDateTime }}",
-    {% endif %}
-  {% endif %}
-
-  {% if imageurl and imageurl != empty %}
-    "image": "{{ imageurl }}",
-  {% endif %}
-  "mainEntityOfPage": "{{ 'Global' | Page:'Url' }}",
-  "name": "{{ Item.Title | Escape }}"
-}
-</script>
-
-
-<!-- Set Meta Tags -->
-{% assign metaTitle = Item | Attribute:'MetaTitle' %}
-{% assign metaDescription = Item | Attribute:'MetaDescription' %}
-{% assign summary = Item | Attribute:'Summary' | StripHtml | StripNewlines %}
-{% assign content = Item.Content | StripHtml | StripNewlines | Truncate:240,'...' %}
-{% capture video %}{{ Item | Attribute:"Video","RawValue" }}{% endcapture %}
-{% capture article_author %}{[ communicatorNames guid:'{{ Item | Attribute:'Communicators','RawValue' }}' ]}{% endcapture %}
-
-{%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
-{% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
-
-{%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
-{% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
-
-
-{[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item | Attribute:"ImageLandscape","Url" }}' article_published_time:'{{ Item.StartDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -235,3 +235,63 @@
     </div>
 
 {[ endscripturize ]}
+
+<!-- Structured Data -->
+{% capture tagsData %}{[ tagData guid:'{{ Item.Guid }}' ]}{% endcapture %}
+{% assign tagsData = tagsData | Trim %}
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Article",
+  "publisher": {
+    "@type": "Organization",
+    "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://newspring.cc/GetImage.ashx?id=661329"
+    }
+  },
+  "author": "{% if communicatorNames and communicatorNames != empty and communicatorNames != '' %}{{ communicatorNames | Trim }}{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}",
+  {% if tagsData and tagsData != empty %}
+    "keywords": "{{ tagsData }}",
+  {% endif %}
+  "headline": "{{ Item.Title | Escape }}",
+  {% if summary and summary != empty %}
+    "description": "{{ summary | StripHtml | Escape }}",
+  {% endif %}
+  "articleBody": "{{ Item.Content | StripHtml | Escape }}",
+  {% if subtitle and subtitle != empty %}
+    "alternativeHeadline": "{{ subtitle }}",
+  {% endif %}
+
+  "datePublished": "{{ Item.StartDateTime }}",
+  "dateModified": "{{ Item.ModifiedDateTime }}",
+    {% if Item.ExpireDateTime %}
+    "expires": "{{ Item.ExpireDateTime }}",
+    {% endif %}
+
+  {% if imageUrl and imageUrl != empty %}
+    "image": "{{ imageUrl }}",
+  {% endif %}
+  "mainEntityOfPage": "{{ 'Global' | Page:'Url' }}",
+  "name": "{{ Item.Title | Escape }}"
+}
+</script>
+
+
+<!-- Set Meta Tags -->
+{% assign metaTitle = Item | Attribute:'MetaTitle' %}
+{% assign metaDescription = Item | Attribute:'MetaDescription' %}
+{% assign summary = Item | Attribute:'Summary' | StripHtml | StripNewlines %}
+{% assign content = Item.Content | StripHtml | StripNewlines | Truncate:240,'...' %}
+{% capture video %}{{ Item | Attribute:"Video","RawValue" }}{% endcapture %}
+{% capture article_author %}{[ communicatorNames guid:'{{ Item | Attribute:'Communicators','RawValue' }}' ]}{% endcapture %}
+
+{%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
+{% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
+
+{%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
+{% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
+
+
+{[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ imageUrl }}' article_published_time:'{{ Item.StartDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -1,100 +1,142 @@
 {% if cciid and cciid != empty %}
-    {% contentchannelitem id:'{{ cciid }}' iterator:'Items' %}
-        {% for Item in Items %}
-            
-            {% capture childIdsConditional %}
-                {% for childItem in Item.ChildItems %}
-                    {% if forloop.first %}
-                        {%- capture childType -%}
-                            {% assign childTypeParts = childItem.ChildContentChannelItem.ContentChannel.Name | Split:' - ' %}
-                            {{ childTypeParts[1] }}
-                        {%- endcapture -%}
-                        {% assign childType = childType | Trim %}
-                    {% endif %}
-                    Id == {{ childItem.ChildContentChannelItem.Id }}{% if forloop.last != true %} || {% endif %}
-                {% endfor %}
-            {% endcapture %}
-            {% if childIdsConditional and childIdsConditional != empty %}
+
+    {% comment %}
+        Determine how we're sorting child items based on the parent channel's (channel of the cciid that was passed in) ManuallyOrdered property.
+    {% endcomment %}
+
+    {% contentchannelitem id:'{{ cciid }}' iterator:'parentItems' %}
+        {% for parentItem in parentItems %}
             {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
-                {% contentchannelitem where:'{{ childIdsConditional }}' sort:'{{ sort }}' iterator:'childItems' %}
-                    {% assign slug = 'Global' | PageParameter:'Slug' %}
-                    {% for child in childItems %}
-                        {% if slug == child.PrimarySlug %}
-                            {% assign initialslide = child.Order %}
-                        {% endif %}
-                    {% endfor %}
-                    {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
-                        {% for child in childItems %}[[ item data:'' ]]
-                            {% assign childChannelId = child.ContentChannel.Id %}
-                            {% capture showDate %}
-                                {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
-                                    {% for channel in channels %}
-                                        {{ channel | Attribute:'IsDateVisible','RawValue' }}
-                                    {% endfor %}
-                                {% endcontentchannel %}
-                            {% endcapture %}
-                            {% assign showDate = showDate | Trim %}
-                            {% capture guid %}{{ child.Guid }}{% endcapture %}
-                            {% capture id %}{{ child.Id }}{% endcapture %}
-                            {% capture cciid %}{{ child.Id }}{% endcapture %}
-                            {% capture type %}{{ childType | Singularize }}{% endcapture %}
-                            {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
-                            {% capture titlesize %}h4{% endcapture %}
-                            {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
-                            {% capture textalignment %}{% endcapture %}
-                            {% capture label %}{% if childType contains "Devotional" %}Session {{ forloop.index }}{% endif %}{% endcapture %}
-                            
-                            {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
-                            {% assign dates = child | Attribute:'Dates','RawValue' %}
-                            {% assign dateParts = dates | Split:',' %}
-                            {% capture subtitle %}
-                                {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
-                                {% if showDate == 'True' %}
-                                    {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
-                                    {% if dates != empty %}
-                                        {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
-                                    {% elseif actualDate != empty %}
-                                        {[ formatDate date:'{{ actualDate }}' ]}
-                                    {% else %}
-                                        {[ formatDate date:'{{ child.StartDateTime }}' ]}
-                                    {% endif %}
-                                {% endif %}
-                            {% endcapture %}
-                            {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
-                            {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
-                            {% capture imageurl %}
-                                {% if childType != "Devotionals" %}
-                                    {% if childimage and childimage != empty %}
-                                        {{ childimage }}
-                                    {% elseif video and video != empty %}
-                                        {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
-                                    {% endif %}
-                                {% endif %}
-                            {% endcapture %}
-                            {% assign imageurl = imageurl | Trim %}
-                            {% capture imageoverlayurl %}{% endcapture %}
-                            {% capture imagealignment %}{% endcapture %}
-                            {% capture imageopacity %}{% endcapture %}
-                            {% capture grayscale %}{% endcapture %}
-                            {% capture backgroundvideourl %}{% endcapture %}
-                            {% capture lava %}{% endcapture %}
-                            {% capture ratio %}{% endcapture %}
-                            {% capture trimcopy %}{% endcapture %}
-                            {% capture linkcolor %}{% endcapture %}
-                            {% capture backgroundcolor %}{% endcapture %}
-                            {% capture linkurl %}{[ getPermalink cciid:'{{ child.Id }}' ]}{% endcapture %}
-                            {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
-                            
-                            {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
-                            
-                        [[ enditem ]]{% endfor %}
-                    {[ endswiper ]}
-                {% endcontentchannelitem %}
-            {% endif %}
+
         {% endfor %}
     {% endcontentchannelitem %}
-{% else %}
-    <div class="alert alert-danger">
-        <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
-    </div>
+
+    {% comment %}
+        Set current item slug so we can determine what the active slide should be
+    {% endcomment %}
+    {% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
+
+    {% if sort == 'Order' %}
+
+        {% comment %}
+            If we're sorting by Order, we've got to start from the ContentChannelItemAssociation table since that's where the Order property is stored.
+        {% endcomment %}
+
+        {% sql %}
+            SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) - 1 'Index', cci.Id, ccis.Slug
+            FROM ContentChannelItemAssociation ccia
+            JOIN ContentChannelItem cci
+            ON ccia.ChildContentChannelItemId = cci.Id
+            JOIN ContentChannelItemSlug ccis
+            ON ccis.ContentChannelItemId = cci.Id
+            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            ORDER BY ccia.[Order]
+        {% endsql %}
+        
+        {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+
+    {% else %}
+
+        {% comment %}
+            If we're sorting by StartDateTime, we can go straight to the ContentChannelItem table since that property is with the other item properties/attributes we need.
+        {% endcomment %}
+
+        {% comment %}
+            Setup array of child content channel item ids ( by default they are`)
+        {% endcomment %}
+        {% sql %}
+            SELECT ROW_NUMBER() OVER (ORDER BY cci.StartDateTime) - 1 'Index', cci.Id, ccis.Slug
+            FROM ContentChannelItemAssociation ccia
+            JOIN ContentChannelItem cci
+            ON ccia.ChildContentChannelItemId = cci.Id
+            JOIN ContentChannelItemSlug ccis
+            ON ccis.ContentChannelItemId = cci.Id
+            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            ORDER BY cci.StartDateTime
+        {% endsql %}
+
+        {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+
+    {% endif %}
+
+    {% comment %}
+        Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.
+    {% endcomment %}
+
+    {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
+        {% for result in results %}
+            [[ item data:'' ]]
+
+                {% contentchannelitem id:'{{ result.Id }}' iterator:'children' %}
+                    {% for child in children %}
+                        {% assign childTypeParts = child.ContentChannel.Name | Split:' - ' %}
+                        {% assign childType = childTypeParts[1] %}
+                        {% assign childChannelId = child.ContentChannel.Id %}
+                        {% capture showDate %}
+                            {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
+                                {% for channel in channels %}
+                                    {{ channel | Attribute:'IsDateVisible','RawValue' }}
+                                {% endfor %}
+                            {% endcontentchannel %}
+                        {% endcapture %}
+                        {% assign showDate = showDate | Trim %}
+                        {% capture guid %}{{ child.Guid }}{% endcapture %}
+                        {% capture id %}{{ child.Id }}{% endcapture %}
+                        {% capture cciid %}{{ child.Id }}{% endcapture %}
+                        {% capture type %}{{ childType | Singularize }}{% endcapture %}
+                        {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
+                        {% capture titlesize %}h4{% endcapture %}
+                        {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
+                        {% capture textalignment %}{% endcapture %}
+                        {% capture label %}{% if childType contains "Devotional" %}Session {{ result.Index | Plus:1 }}{% endif %}{% endcapture %}
+                        
+                        {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
+                        {% assign dates = child | Attribute:'Dates','RawValue' %}
+                        {% assign dateParts = dates | Split:',' %}
+                        {% capture subtitle %}
+                            {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
+                            {% if showDate == 'True' %}
+                                {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
+                                {% if dates != empty %}
+                                    {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
+                                {% elseif actualDate != empty %}
+                                    {[ formatDate date:'{{ actualDate }}' ]}
+                                {% else %}
+                                    {[ formatDate date:'{{ child.StartDateTime }}' ]}
+                                {% endif %}
+                            {% endif %}
+                        {% endcapture %}
+                        {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
+                        {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
+                        {% capture imageurl %}
+                            {% if childType != "Devotionals" %}
+                                {% if childimage and childimage != empty %}
+                                    {{ childimage }}
+                                {% elseif video and video != empty %}
+                                    {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
+                                {% endif %}
+                            {% endif %}
+                        {% endcapture %}
+                        {% assign imageurl = imageurl | Trim %}
+                        {% capture imageoverlayurl %}{% endcapture %}
+                        {% capture imagealignment %}{% endcapture %}
+                        {% capture imageopacity %}{% endcapture %}
+                        {% capture grayscale %}{% endcapture %}
+                        {% capture backgroundvideourl %}{% endcapture %}
+                        {% capture lava %}{% endcapture %}
+                        {% capture ratio %}{% endcapture %}
+                        {% capture trimcopy %}{% endcapture %}
+                        {% capture linkcolor %}{% endcapture %}
+                        {% capture backgroundcolor %}{% endcapture %}
+                        {% capture linkurl %}{[ getPermalink cciid:'{{ child.Id }}' ]}{% endcapture %}
+                        {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
+                        
+                        {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+                    {% endfor %}
+                {% endcontentchannelitem %}
+
+            [[ enditem ]]
+        {% endfor %}
+    {[ endswiper ]}
+
 {% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -139,4 +139,8 @@
         {% endfor %}
     {[ endswiper ]}
 
+{% else %}
+    <div class="alert alert-danger">
+        <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
+    </div>
 {% endif %}


### PR DESCRIPTION
## DESCRIPTION

Spark recently made a change where the `Order` property (the thing that determines what order child content channel items are displayed) is now stored in the `ContentChannelItemAssociation` table, rather than the `ContentChannelItem` table.

Because of this change, we needed to:
1. Copy those values over to the `ContentChannelItemAssociation` table.
2. Update any lava that references those values - specifically the `Child Items Swiper` and `Editorial Detail` templates.

### How do I test this PR?

- [ ] Pages that use the `Child Items Swiper` and `Editorial Detail` templates should display content and function as expected.
- https://brian-new.newspring.cc/articles (Editorial Detail only)
- https://brian-new.newspring.cc/devotionals
- https://brian-new.newspring.cc/fuse/devotionals
- https://brian-new.newspring.cc/news (Editorial Detail only)
- https://brian-new.newspring.cc/sermons (Child Items Swiper only)
- https://brian-new.newspring.cc/stories (Editorial Detail only)
- [ ] The `Child Items Swiper` should have the first child item as the active slide, unless you're viewing an actual entry - in which case, the entry you are viewing should be the active slide.
- [ ] The `Editorial Detail` template should show the correction session number for devotionals.
- [ ] The `Editorial Detail` template should show `Next` and `Prev` buttons when viewing devotionals so that you can successfully navigate between sessions.
- [ ] News entry pages should show the date at the bottom of the content, while all other content should not.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
