### PR TITLE
Removed Sentry from the Fuse and KidSpring master layouts

### DIFF
--- a/RockWeb/Themes/Fuse/Layouts/Site.Master
+++ b/RockWeb/Themes/Fuse/Layouts/Site.Master
@@ -27,12 +27,6 @@
     <meta charset="utf-8">
     <title></title>
 
-    <!-- Sentry -->
-    <script src="https://cdn.ravenjs.com/3.5.1/raven.min.js"></script>
-    <script type="text/javascript">
-        Raven.config("<%# Rock.Web.Cache.GlobalAttributesCache.Read().GetValue( "PublicSentryDSN" ) %>").install();
-    </script>
-
     <script type="text/javascript">var _sf_startpt = (new Date()).getTime()</script>
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js", true) %>"></script>
     <script src="<%# ResolveRockUrl("~/Scripts/jquery-1.10.2.min.js", true) %>"></script>

--- a/RockWeb/Themes/KidSpring/Layouts/Site.Master
+++ b/RockWeb/Themes/KidSpring/Layouts/Site.Master
@@ -26,12 +26,6 @@
     <meta charset="utf-8">
     <title></title>
 
-    <!-- Sentry -->
-    <script src="https://cdn.ravenjs.com/3.5.1/raven.min.js"></script>
-    <script type="text/javascript">
-        Raven.config("<%# Rock.Web.Cache.GlobalAttributesCache.Read().GetValue( "PublicSentryDSN" ) %>").install();
-    </script>
-
     <script type="text/javascript">var _sf_startpt = (new Date()).getTime()</script>
     <script src="<%# ResolveRockUrl("~/Scripts/modernizr.js", true) %>"></script>
     <script src="<%# ResolveRockUrl("~/Scripts/jquery-1.10.2.min.js", true) %>"></script>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR removes the Sentry reporting section from the Fuse and KidSpring `Site.Master` files. An obsolete call in this section is what we think was causing Attended Checkin to fail.

### How do I test this PR?
We're planning on just pushing this to `alpha-rock`. You can attempt to run checkin locally to see if it works.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
