### PR TITLE
Added to sql query in child items swiper to omit future dated content, expired content, and pending/denied content

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -7,7 +7,6 @@
     {% contentchannelitem id:'{{ cciid }}' iterator:'parentItems' %}
         {% for parentItem in parentItems %}
             {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
-
         {% endfor %}
     {% endcontentchannelitem %}
 
@@ -30,6 +29,9 @@
             JOIN ContentChannelItemSlug ccis
             ON ccis.ContentChannelItemId = cci.Id
             WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            AND cci.Status = 2
+            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
             ORDER BY ccia.[Order]
         {% endsql %}
         
@@ -52,6 +54,9 @@
             JOIN ContentChannelItemSlug ccis
             ON ccis.ContentChannelItemId = cci.Id
             WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            AND cci.Status = 2
+            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
             ORDER BY cci.StartDateTime
         {% endsql %}
 


### PR DESCRIPTION
## DESCRIPTION

Currently, the child items swiper (used for devotionals and sermons) is displaying content that has a StartDateTime value that is in the future, ExpireDateTime that is in the past, or items that have a Pending or Denied status.

Functionally, we use StartDateTime & ExpireDateTime to automate the publishing/removal of content, and status to show/hide content in general. This update brings the `child-items-swiper` lava template up to date to respect the intended use of these three properties.

### How do I test this PR?

1. Publish a sermon or devotional that has one or multiple of the following:
- A StartDateTime that is in the future
- An ExpireDateTime that is in the past
- A Status of Pending or Denied

2. Verify that the entry you created is NOT visible on the series/study page that contains it.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
