### PR TITLE
Updated Form Timeout

### DIFF
--- a/RockWeb/web.config
+++ b/RockWeb/web.config
@@ -59,7 +59,7 @@
       </expressionBuilders>
     </compilation>
     <authentication mode="Forms">
-      <forms name=".ROCK" loginUrl="Login" defaultUrl="Page/12" timeout="43200" />
+      <forms name=".ROCK" loginUrl="Login" defaultUrl="Page/12" timeout="576000" />
     </authentication>
     <!-- max request size - rock default 100 MB -->
     <httpRuntime targetFramework="4.5.2" requestValidationMode="4.5" requestValidationType="Rock.Web.RequestValidator" relaxedUrlToFileSystemMapping="true" maxRequestLength="102400" />


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR updates the form timeout in the `web.config` file to match what is already on the servers. Basically this changes the timeout to be 400 days instead of 30 days. The idea here is that a Rock session shouldn't timeout for over a year. 

### How do I test this PR?
You can't. Sorry. 😢 

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
