### PR TITLE
Fixes custom prayer API endpoint for groups

### DIFF
--- a/Rock.Rest/Controllers/PrayerRequestsController.Partial.cs
+++ b/Rock.Rest/Controllers/PrayerRequestsController.Partial.cs
@@ -154,6 +154,7 @@ namespace Rock.Rest.Controllers
         /// <returns></returns>
         [Authenticate, Secured]
         [HttpGet]
+        [EnableQuery]
         [System.Web.Http.Route( "api/PrayerRequests/GetForGroupMembersOfPersonInGroupTypes/{personId}" )]
         public IQueryable<PrayerRequest> GetForGroupMembersOfPersonInGroupTypes( bool excludePerson, string groupTypeIds, int personId )
         {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the `GetForGroupMembersOfPersonInGroupTypes` endpoint to correctly handle OData calls.

### How do I test this PR?
Before pulling this branch locally:
* Pull the latest from `alpha`, run migrations and do a clean and build of the solution.
* Make sure that you are a part of a group and that only one person has 1 prayer in that group.
* Pull up the Swagger docs and test the `GetForGroupMembersOfPersonInGroupTypes` endpoint (under `PrayerRequests`) with something similar to `https://rock.test/api/PrayerRequests/GetForGroupMembersOfPersonInGroupTypes/158648?excludePerson=true&groupTypeIds=10%2C23%2C25%2C60%2C141%2C149&$top=1&$skip=1`
* You should see that even using the `skip=1` returns the same prayer as if you didn't use it.

Then pull this branch. Do the same thing. If you don't use the `skip=1` you should get the 1 prayer correctly. If you do use the `skip=1`, you should get an empty array.

![Screenshot 2020-02-13 10 46 43](https://user-images.githubusercontent.com/3229463/74452635-52fe4580-4e4f-11ea-8a78-34c7d04e9a9c.png)

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
