### PR TITLE
Updated links to workflow for download interactions to include asset name only as resource description

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
@@ -3,15 +3,12 @@
 {% assign offset = currentpage | Times:pagesize | Minus:pagesize %}
 {% assign pagesize = pagesize | AsInteger %}
 
+
 <section>
     <div class="row">
     	{% for item in Items limit:pagesize offset:offset %}<div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
 
-			{% contentchannel id:'{{ item.ContentChannelId }}' iterator:'channels' %}
-				{% for channel in channels %}
-					{% assign showDate = channel | Attribute:'IsDateVisible' %}
-				{% endfor %}
-			{% endcontentchannel %}
+			{% assign showDate = item.ContentChannel | Attribute:'IsDateVisible' %}
 
             {% assign id = item.Id %}
             {% assign cciid = item.Id %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/network-resource-collection.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/network-resource-collection.lava
@@ -55,7 +55,7 @@
                 <p class="push-half-bottom">{{ attribute.Summary }}</p>
                 <p>
                 {% if CurrentPerson and CurrentPerson != empty %}
-                    <a href="/workflows/617?PersonAliasId={{ CurrentPerson.PrimaryAliasId }}&ResourceId={{ Item.Id }}&ResourceImage={{ Item | Attribute:'ImageLandscape','Url' }}&ResourceTitle={{ Item.Title | Replace:"'","’" | EscapeDataString }}: {{ attribute.Title | Replace:"'","’" | EscapeDataString }}&ResourceSummary={{ attribute.Summary | Replace:"'","’" | EscapeDataString }}&ResourceUrl={% if attribute.Link != empty %}{{ attribute.Link }}{% else %}{{ attribute.File }}{% endif %}" class="btn btn-primary" target="_blank">Download Now</a>
+                    <a href="/workflows/617?PersonAliasId={{ CurrentPerson.PrimaryAliasId }}&ResourceId={{ Item.Id }}&ResourceImage={{ Item | Attribute:'ImageLandscape','Url' }}&ResourceTitle={{ Item.Title | Replace:"'","’" | EscapeDataString }}&ResourceSummary={{ attribute.Title | Replace:"'","’" | EscapeDataString }}&ResourceUrl={% if attribute.Link != empty %}{{ attribute.Link }}{% else %}{{ attribute.File }}{% endif %}" class="btn btn-primary" target="_blank">Download Now</a>
                 {% else %}
                     <a href="/sign-in?returnurl={{ currentUrl }}" class="btn btn-primary">Sign In to Download</a>
                 {% endif %}


### PR DESCRIPTION
## DESCRIPTION

This PR updates the links that launch the "download resource" workflow to include the resource title as the description instead of the longer summary.

Also trimmed down how we get the value of the `IsDateVisible` attribute to be less expensive.

### How do I test this PR?

Since the workflow Id is different in production than anywhere else, you don't. 🙈 

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
