### PR TITLE
Fix Location Gathering Info Spacing

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -18,7 +18,7 @@
 <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
     <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
         <h3 class="push-half-bottom">Sunday Gatherings</h3>
-        <p class="spush-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
+        <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
         <p class="lead">{{ serviceTimes }}
         {% if getDirections != empty %}
             <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
@@ -26,7 +26,7 @@
         </p>
     </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
         <h3 class="push-half-bottom">Fuse Student Ministry</h3>
-        <p class="spush-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
+        <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
         <p class="lead">{{ fuseServiceTimes }}</p>
     </div>{% endif %}
 </div>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -18,7 +18,7 @@
 <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
     <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
         <h3 class="push-half-bottom">Sunday Gatherings</h3>
-        <p class="mx-auto push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
+        <p class="spush-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
         <p class="lead">{{ serviceTimes }}
         {% if getDirections != empty %}
             <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
@@ -26,7 +26,7 @@
         </p>
     </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
         <h3 class="push-half-bottom">Fuse Student Ministry</h3>
-        <p class="mx-auto push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
+        <p class="spush-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
         <p class="lead">{{ fuseServiceTimes }}</p>
     </div>{% endif %}
 </div>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the gathering information spacing on the location pages. 

Before:
<img width="1792" alt="Screenshot 2020-03-19 13 33 40" src="https://user-images.githubusercontent.com/3229463/77096956-6e2c1a00-69e6-11ea-9736-3e04c65cac1a.png">

After:
<img width="1792" alt="Screenshot 2020-03-19 13 34 23" src="https://user-images.githubusercontent.com/3229463/77096972-73896480-69e6-11ea-9075-d426929e7734.png">

### How do I test this PR?
Run this locally and make sure that the gathering information is spaced correctly.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
