### PR TITLE
Update Child Items Swiper to Highlight Most Recent Item for Current Series

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -1,161 +1,150 @@
-{% for child in Item.ChildItems limit:1 %}
+{% if cciid and cciid != empty %}
+    {% assign now = 'Now' | Date:'yyyy-MM-ddThh:mm:ss.000000' %}
+    {% assign startDate = Item | Attribute:'Dates','RawValue' | Split:',' | First %}
+    {% assign endDate = Item | Attribute:'Dates','RawValue' | Split:',' | Last %}
+
 
     {% comment %}
-        {[ childItemsSwiper title:'Sermons From This Series' cciid:'{{ child.ContentChannelItemId }}' ]}
+        Set current item slug so we can determine what the active slide should be
     {% endcomment %}
+    {% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
 
-    {% assign cciid = child.ContentChannelItemId %}
+    {% comment %}
+        Determine how we're sorting child items based on the parent channel's (channel of the cciid that was passed in) ManuallyOrdered property.
+    {% endcomment %}
+    {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
 
-    {% if cciid and cciid != empty %}
-        {% assign now = 'Now' | Date:'yyyy-MM-ddThh:mm:ss.000000' %}
-        {% assign startDate = Item | Attribute:'Dates','RawValue' | Split:',' | First %}
-        {% assign endDate = Item | Attribute:'Dates','RawValue' | Split:',' | Last %}
+    {% sql %}
+        {% if sort == 'Order' %}
 
+            /* If we're sorting by Order, we've got to start from the ContentChannelItemAssociation table since that's where the Order property is stored. */
+            SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) - 1 'Index', cci.Id, ccis.Slug
+            FROM ContentChannelItemAssociation ccia
+            JOIN ContentChannelItem cci
+            ON ccia.ChildContentChannelItemId = cci.Id
+            JOIN ContentChannelItemSlug ccis
+            ON ccis.ContentChannelItemId = cci.Id
+            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
+            AND cci.Status = 2
+            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
+            ORDER BY ccia.[Order]
 
-        {% comment %}
-            Set current item slug so we can determine what the active slide should be
-        {% endcomment %}
-        {% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
-
-        {% comment %}
-            Determine how we're sorting child items based on the parent channel's (channel of the cciid that was passed in) ManuallyOrdered property.
-        {% endcomment %}
-        {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
-
-        {% sql %}
-            {% if sort == 'Order' %}
-
-                /* If we're sorting by Order, we've got to start from the ContentChannelItemAssociation table since that's where the Order property is stored. */
-                SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) - 1 'Index', cci.Id, ccis.Slug
-                FROM ContentChannelItemAssociation ccia
-                JOIN ContentChannelItem cci
-                ON ccia.ChildContentChannelItemId = cci.Id
-                JOIN ContentChannelItemSlug ccis
-                ON ccis.ContentChannelItemId = cci.Id
-                WHERE ccia.ContentChannelItemId = '{{ cciid }}'
-                {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
-                AND cci.Status = 2
-                AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
-                AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
-                ORDER BY ccia.[Order]
-
-            {% else %}
-
-                /* If we're sorting by StartDateTime, we can go straight to the ContentChannelItem table since that property is with the other item properties/attributes we need. */
-                SELECT ROW_NUMBER() OVER (ORDER BY cci.StartDateTime) - 1 'Index', cci.Id, ccis.Slug
-                FROM ContentChannelItemAssociation ccia
-                JOIN ContentChannelItem cci
-                ON ccia.ChildContentChannelItemId = cci.Id
-                JOIN ContentChannelItemSlug ccis
-                ON ccis.ContentChannelItemId = cci.Id
-                WHERE ccia.ContentChannelItemId = '{{ cciid }}'
-                {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
-                AND cci.Status = 2
-                AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
-                AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
-                ORDER BY cci.StartDateTime
-
-            {% endif %}
-        {% endsql %}
-
-        {% comment %}
-            If we're between the beginning/ending dates of this collection, make the last item in the swiper active
-        {% endcomment %}
-        {% if now >= startDate and now < endDate %}
-            {% assign initialslide = results | Size | Minus:1 %}
         {% else %}
-            {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+
+            /* If we're sorting by StartDateTime, we can go straight to the ContentChannelItem table since that property is with the other item properties/attributes we need. */
+            SELECT ROW_NUMBER() OVER (ORDER BY cci.StartDateTime) - 1 'Index', cci.Id, ccis.Slug
+            FROM ContentChannelItemAssociation ccia
+            JOIN ContentChannelItem cci
+            ON ccia.ChildContentChannelItemId = cci.Id
+            JOIN ContentChannelItemSlug ccis
+            ON ccis.ContentChannelItemId = cci.Id
+            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+            {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
+            AND cci.Status = 2
+            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
+            ORDER BY cci.StartDateTime
+
         {% endif %}
+    {% endsql %}
 
-        {% comment %}
-            Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.
-        {% endcomment %}
-
-        {% assign childCount = results | Size %}
-        {% if childCount >= 1 %}
-        {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
-            {% for result in results %}
-                [[ item data:'' ]]
-
-                    {% contentchannelitem id:'{{ result.Id }}' iterator:'children' %}
-                        
-                        {% for child in children %}
-                            {% assign childTypeParts = child.ContentChannel.Name | Split:' - ' %}
-                            {% assign childType = childTypeParts[1] %}
-                            {% assign childChannelId = child.ContentChannel.Id %}
-                            {% capture showDate %}
-                                {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
-                                    {% for channel in channels %}
-                                        {{ channel | Attribute:'IsDateVisible','RawValue' }}
-                                    {% endfor %}
-                                {% endcontentchannel %}
-                            {% endcapture %}
-                            {% assign showDate = showDate | Trim %}
-                            {% capture guid %}{{ child.Guid }}{% endcapture %}
-                            {% capture id %}{{ child.Id }}{% endcapture %}
-                            {% capture cciid %}{{ child.Id }}{% endcapture %}
-                            {% capture type %}{{ childType | Singularize }}{% endcapture %}
-                            {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
-                            {% capture titlesize %}h4{% endcapture %}
-                            {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
-                            {% capture textalignment %}{% endcapture %}
-                            {% capture label %}{% if childType contains "Devotional" %}Session {{ result.Index | Plus:1 }}{% endif %}{% endcapture %}
-
-                            {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
-                            {% assign dates = child | Attribute:'Dates','RawValue' %}
-                            {% assign dateParts = dates | Split:',' %}
-                            {% capture subtitle %}
-                                {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
-                                {% if showDate == 'True' %}
-                                    {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
-                                    {% if dates != empty %}
-                                        {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
-                                    {% elseif actualDate != empty %}
-                                        {[ formatDate date:'{{ actualDate }}' ]}
-                                    {% else %}
-                                        {[ formatDate date:'{{ child.StartDateTime }}' ]}
-                                    {% endif %}
-                                {% endif %}
-                            {% endcapture %}
-                            {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
-                            {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
-                            {% capture imageurl %}
-                                {% if childType != "Devotionals" %}
-                                    {% if childimage and childimage != empty %}
-                                        {{ childimage }}
-                                    {% elseif video and video != empty %}
-                                        {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
-                                    {% endif %}
-                                {% endif %}
-                            {% endcapture %}
-                            {% assign imageurl = imageurl | Trim %}
-                            {% capture imageoverlayurl %}{% endcapture %}
-                            {% capture imagealignment %}{% endcapture %}
-                            {% capture imageopacity %}{% endcapture %}
-                            {% capture grayscale %}{% endcapture %}
-                            {% capture backgroundvideourl %}{% endcapture %}
-                            {% capture lava %}{% endcapture %}
-                            {% capture ratio %}{% endcapture %}
-                            {% capture trimcopy %}{% endcapture %}
-                            {% capture linkcolor %}{% endcapture %}
-                            {% capture backgroundcolor %}{% endcapture %}
-                            {% capture linkurl %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ child.Id }}' ]}{% endcapture %}
-                            {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
-
-                            {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
-                        {% endfor %}
-                    {% endcontentchannelitem %}
-
-                [[ enditem ]]
-            {% endfor %}
-        {[ endswiper ]}
-        {% endif %}
-
+    {% comment %}
+        If we're between the beginning/ending dates of this collection, make the last item in the swiper active
+    {% endcomment %}
+    {% if now >= startDate and now < endDate %}
+        {% assign initialslide = results | Size | Minus:1 %}
     {% else %}
-        <div class="alert alert-danger">
-            <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
-        </div>
+        {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
     {% endif %}
 
+    {% comment %}
+        Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.
+    {% endcomment %}
 
-{% endfor %}
+    {% assign childCount = results | Size %}
+    {% if childCount >= 1 %}
+    {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
+        {% for result in results %}
+            [[ item data:'' ]]
+
+                {% contentchannelitem id:'{{ result.Id }}' iterator:'children' %}
+                    
+                    {% for child in children %}
+                        {% assign childTypeParts = child.ContentChannel.Name | Split:' - ' %}
+                        {% assign childType = childTypeParts[1] %}
+                        {% assign childChannelId = child.ContentChannel.Id %}
+                        {% capture showDate %}
+                            {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
+                                {% for channel in channels %}
+                                    {{ channel | Attribute:'IsDateVisible','RawValue' }}
+                                {% endfor %}
+                            {% endcontentchannel %}
+                        {% endcapture %}
+                        {% assign showDate = showDate | Trim %}
+                        {% capture guid %}{{ child.Guid }}{% endcapture %}
+                        {% capture id %}{{ child.Id }}{% endcapture %}
+                        {% capture cciid %}{{ child.Id }}{% endcapture %}
+                        {% capture type %}{{ childType | Singularize }}{% endcapture %}
+                        {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
+                        {% capture titlesize %}h4{% endcapture %}
+                        {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
+                        {% capture textalignment %}{% endcapture %}
+                        {% capture label %}{% if childType contains "Devotional" %}Session {{ result.Index | Plus:1 }}{% endif %}{% endcapture %}
+
+                        {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
+                        {% assign dates = child | Attribute:'Dates','RawValue' %}
+                        {% assign dateParts = dates | Split:',' %}
+                        {% capture subtitle %}
+                            {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
+                            {% if showDate == 'True' %}
+                                {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
+                                {% if dates != empty %}
+                                    {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
+                                {% elseif actualDate != empty %}
+                                    {[ formatDate date:'{{ actualDate }}' ]}
+                                {% else %}
+                                    {[ formatDate date:'{{ child.StartDateTime }}' ]}
+                                {% endif %}
+                            {% endif %}
+                        {% endcapture %}
+                        {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
+                        {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
+                        {% capture imageurl %}
+                            {% if childType != "Devotionals" %}
+                                {% if childimage and childimage != empty %}
+                                    {{ childimage }}
+                                {% elseif video and video != empty %}
+                                    {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
+                                {% endif %}
+                            {% endif %}
+                        {% endcapture %}
+                        {% assign imageurl = imageurl | Trim %}
+                        {% capture imageoverlayurl %}{% endcapture %}
+                        {% capture imagealignment %}{% endcapture %}
+                        {% capture imageopacity %}{% endcapture %}
+                        {% capture grayscale %}{% endcapture %}
+                        {% capture backgroundvideourl %}{% endcapture %}
+                        {% capture lava %}{% endcapture %}
+                        {% capture ratio %}{% endcapture %}
+                        {% capture trimcopy %}{% endcapture %}
+                        {% capture linkcolor %}{% endcapture %}
+                        {% capture backgroundcolor %}{% endcapture %}
+                        {% capture linkurl %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ child.Id }}' ]}{% endcapture %}
+                        {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
+
+                        {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+                    {% endfor %}
+                {% endcontentchannelitem %}
+
+            [[ enditem ]]
+        {% endfor %}
+    {[ endswiper ]}
+    {% endif %}
+
+{% else %}
+    <div class="alert alert-danger">
+        <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
+    </div>
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -1,146 +1,161 @@
-{% if cciid and cciid != empty %}
-    {% assign now = 'Now' | Date:'yyyy-MM-ddThh:mm:ss.000000' %}
-    {% assign startDate = Item | Attribute:'Dates','RawValue' | Split:',' | First %}
-    {% assign endDate = Item | Attribute:'Dates','RawValue' | Split:',' | Last %}
-
+{% for child in Item.ChildItems limit:1 %}
 
     {% comment %}
-        Set current item slug so we can determine what the active slide should be
+        {[ childItemsSwiper title:'Sermons From This Series' cciid:'{{ child.ContentChannelItemId }}' ]}
     {% endcomment %}
-    {% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
 
-    {% comment %}
-        Determine how we're sorting child items based on the parent channel's (channel of the cciid that was passed in) ManuallyOrdered property.
-    {% endcomment %}
-    {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
+    {% assign cciid = child.ContentChannelItemId %}
 
-    {% sql %}
-        {% if sort == 'Order' %}
+    {% if cciid and cciid != empty %}
+        {% assign now = 'Now' | Date:'yyyy-MM-ddThh:mm:ss.000000' %}
+        {% assign startDate = Item | Attribute:'Dates','RawValue' | Split:',' | First %}
+        {% assign endDate = Item | Attribute:'Dates','RawValue' | Split:',' | Last %}
 
-            /* If we're sorting by Order, we've got to start from the ContentChannelItemAssociation table since that's where the Order property is stored. */
-            SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) - 1 'Index', cci.Id, ccis.Slug
-            FROM ContentChannelItemAssociation ccia
-            JOIN ContentChannelItem cci
-            ON ccia.ChildContentChannelItemId = cci.Id
-            JOIN ContentChannelItemSlug ccis
-            ON ccis.ContentChannelItemId = cci.Id
-            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
-            {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
-            AND cci.Status = 2
-            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
-            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
-            ORDER BY ccia.[Order]
 
+        {% comment %}
+            Set current item slug so we can determine what the active slide should be
+        {% endcomment %}
+        {% assign currentSlug = 'Global' | Page:'Path' | Split:'/' | Last %}
+
+        {% comment %}
+            Determine how we're sorting child items based on the parent channel's (channel of the cciid that was passed in) ManuallyOrdered property.
+        {% endcomment %}
+        {% capture sort %}{% if Item.ContentChannel.ChildItemsManuallyOrdered == true %}Order{% else %}StartDateTime{% endif %}{% endcapture %}
+
+        {% sql %}
+            {% if sort == 'Order' %}
+
+                /* If we're sorting by Order, we've got to start from the ContentChannelItemAssociation table since that's where the Order property is stored. */
+                SELECT ROW_NUMBER() OVER (ORDER BY ccia.[Order]) - 1 'Index', cci.Id, ccis.Slug
+                FROM ContentChannelItemAssociation ccia
+                JOIN ContentChannelItem cci
+                ON ccia.ChildContentChannelItemId = cci.Id
+                JOIN ContentChannelItemSlug ccis
+                ON ccis.ContentChannelItemId = cci.Id
+                WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+                {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
+                AND cci.Status = 2
+                AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+                AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
+                ORDER BY ccia.[Order]
+
+            {% else %}
+
+                /* If we're sorting by StartDateTime, we can go straight to the ContentChannelItem table since that property is with the other item properties/attributes we need. */
+                SELECT ROW_NUMBER() OVER (ORDER BY cci.StartDateTime) - 1 'Index', cci.Id, ccis.Slug
+                FROM ContentChannelItemAssociation ccia
+                JOIN ContentChannelItem cci
+                ON ccia.ChildContentChannelItemId = cci.Id
+                JOIN ContentChannelItemSlug ccis
+                ON ccis.ContentChannelItemId = cci.Id
+                WHERE ccia.ContentChannelItemId = '{{ cciid }}'
+                {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
+                AND cci.Status = 2
+                AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
+                AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
+                ORDER BY cci.StartDateTime
+
+            {% endif %}
+        {% endsql %}
+
+        {% comment %}
+            If we're between the beginning/ending dates of this collection, make the last item in the swiper active
+        {% endcomment %}
+        {% if now >= startDate and now < endDate %}
+            {% assign initialslide = results | Size | Minus:1 %}
         {% else %}
-
-            /* If we're sorting by StartDateTime, we can go straight to the ContentChannelItem table since that property is with the other item properties/attributes we need. */
-            SELECT ROW_NUMBER() OVER (ORDER BY cci.StartDateTime) - 1 'Index', cci.Id, ccis.Slug
-            FROM ContentChannelItemAssociation ccia
-            JOIN ContentChannelItem cci
-            ON ccia.ChildContentChannelItemId = cci.Id
-            JOIN ContentChannelItemSlug ccis
-            ON ccis.ContentChannelItemId = cci.Id
-            WHERE ccia.ContentChannelItemId = '{{ cciid }}'
-            {% if ccids and ccids != empty %}AND cci.ContentChannelId IN ({{ ccids }}){% endif %}
-            AND cci.Status = 2
-            AND cci.StartDateTime <= DATEADD(hh, -5, GETDATE())
-            AND (cci.ExpireDateTime IS NULL OR cci.ExpireDateTime IS NOT NULL AND cci.ExpireDateTime > DATEADD(hh, -5, GETDATE()))
-            ORDER BY cci.StartDateTime
-
+            {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
         {% endif %}
-    {% endsql %}
 
-    {% comment %}
-        If we're between the beginning/ending dates of this collection, make the last item in the swiper active
-    {% endcomment %}
-    {% if now >= startDate and now < endDate %}
-        {% assign initialslide = results | Size | Minus:1 %}
+        {% comment %}
+            Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.
+        {% endcomment %}
+
+        {% assign childCount = results | Size %}
+        {% if childCount >= 1 %}
+        {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
+            {% for result in results %}
+                [[ item data:'' ]]
+
+                    {% contentchannelitem id:'{{ result.Id }}' iterator:'children' %}
+                        
+                        {% for child in children %}
+                            {% assign childTypeParts = child.ContentChannel.Name | Split:' - ' %}
+                            {% assign childType = childTypeParts[1] %}
+                            {% assign childChannelId = child.ContentChannel.Id %}
+                            {% capture showDate %}
+                                {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
+                                    {% for channel in channels %}
+                                        {{ channel | Attribute:'IsDateVisible','RawValue' }}
+                                    {% endfor %}
+                                {% endcontentchannel %}
+                            {% endcapture %}
+                            {% assign showDate = showDate | Trim %}
+                            {% capture guid %}{{ child.Guid }}{% endcapture %}
+                            {% capture id %}{{ child.Id }}{% endcapture %}
+                            {% capture cciid %}{{ child.Id }}{% endcapture %}
+                            {% capture type %}{{ childType | Singularize }}{% endcapture %}
+                            {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
+                            {% capture titlesize %}h4{% endcapture %}
+                            {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
+                            {% capture textalignment %}{% endcapture %}
+                            {% capture label %}{% if childType contains "Devotional" %}Session {{ result.Index | Plus:1 }}{% endif %}{% endcapture %}
+
+                            {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
+                            {% assign dates = child | Attribute:'Dates','RawValue' %}
+                            {% assign dateParts = dates | Split:',' %}
+                            {% capture subtitle %}
+                                {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
+                                {% if showDate == 'True' %}
+                                    {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
+                                    {% if dates != empty %}
+                                        {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
+                                    {% elseif actualDate != empty %}
+                                        {[ formatDate date:'{{ actualDate }}' ]}
+                                    {% else %}
+                                        {[ formatDate date:'{{ child.StartDateTime }}' ]}
+                                    {% endif %}
+                                {% endif %}
+                            {% endcapture %}
+                            {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
+                            {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
+                            {% capture imageurl %}
+                                {% if childType != "Devotionals" %}
+                                    {% if childimage and childimage != empty %}
+                                        {{ childimage }}
+                                    {% elseif video and video != empty %}
+                                        {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
+                                    {% endif %}
+                                {% endif %}
+                            {% endcapture %}
+                            {% assign imageurl = imageurl | Trim %}
+                            {% capture imageoverlayurl %}{% endcapture %}
+                            {% capture imagealignment %}{% endcapture %}
+                            {% capture imageopacity %}{% endcapture %}
+                            {% capture grayscale %}{% endcapture %}
+                            {% capture backgroundvideourl %}{% endcapture %}
+                            {% capture lava %}{% endcapture %}
+                            {% capture ratio %}{% endcapture %}
+                            {% capture trimcopy %}{% endcapture %}
+                            {% capture linkcolor %}{% endcapture %}
+                            {% capture backgroundcolor %}{% endcapture %}
+                            {% capture linkurl %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ child.Id }}' ]}{% endcapture %}
+                            {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
+
+                            {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+                        {% endfor %}
+                    {% endcontentchannelitem %}
+
+                [[ enditem ]]
+            {% endfor %}
+        {[ endswiper ]}
+        {% endif %}
+
     {% else %}
-        {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+        <div class="alert alert-danger">
+            <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
+        </div>
     {% endif %}
 
-    {% comment %}
-        Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.
-    {% endcomment %}
 
-    {[ swiper id:'entries' initialslide:'{{ initialslide }}' ]}
-        {% for result in results %}
-            [[ item data:'' ]]
-
-                {% contentchannelitem id:'{{ result.Id }}' iterator:'children' %}
-                    {% for child in children %}
-                        {% assign childTypeParts = child.ContentChannel.Name | Split:' - ' %}
-                        {% assign childType = childTypeParts[1] %}
-                        {% assign childChannelId = child.ContentChannel.Id %}
-                        {% capture showDate %}
-                            {% contentchannel where:'Id == {{ childChannelId | AsInteger }}' iterator:'channels' %}
-                                {% for channel in channels %}
-                                    {{ channel | Attribute:'IsDateVisible','RawValue' }}
-                                {% endfor %}
-                            {% endcontentchannel %}
-                        {% endcapture %}
-                        {% assign showDate = showDate | Trim %}
-                        {% capture guid %}{{ child.Guid }}{% endcapture %}
-                        {% capture id %}{{ child.Id }}{% endcapture %}
-                        {% capture cciid %}{{ child.Id }}{% endcapture %}
-                        {% capture type %}{{ childType | Singularize }}{% endcapture %}
-                        {% capture title %}{{ child.Title | Replace:"'","’" }}{% endcapture %}
-                        {% capture titlesize %}h4{% endcapture %}
-                        {% capture content %}{% if child.Content != empty %}<p class="push-half-bottom">{{ child.Content | StripHtml | HtmlDecode | Replace:"'","’" | Truncate:140,'...' }}</p>{% endif %}{% endcapture %}
-                        {% capture textalignment %}{% endcapture %}
-                        {% capture label %}{% if childType contains "Devotional" %}Session {{ result.Index | Plus:1 }}{% endif %}{% endcapture %}
-
-                        {% assign actualDate = child | Attribute:'ActualDate','RawValue' %}
-                        {% assign dates = child | Attribute:'Dates','RawValue' %}
-                        {% assign dateParts = dates | Split:',' %}
-                        {% capture subtitle %}
-                            {%- comment -%}Check this item's channel to see if dates should be visible{%- endcomment -%}
-                            {% if showDate == 'True' %}
-                                {%- comment -%}If item has a date range, display it - otherwise display the item start date{%- endcomment -%}
-                                {% if dates != empty %}
-                                    {[ formatDate date:'{{ dateParts[0] }}' ]}{% if dateParts[1] != dateParts[0] %} - {[ formatDate date:'{{ dateParts[1] }}' ]}{% endif %}
-                                {% elseif actualDate != empty %}
-                                    {[ formatDate date:'{{ actualDate }}' ]}
-                                {% else %}
-                                    {[ formatDate date:'{{ child.StartDateTime }}' ]}
-                                {% endif %}
-                            {% endif %}
-                        {% endcapture %}
-                        {% capture video %}{{ child | Attribute:'Video','RawValue' }}{% endcapture %}
-                        {% capture childimage %}{{ child | Attribute:'ImageLandscape','Url' }}{% endcapture %}
-                        {% capture imageurl %}
-                            {% if childType != "Devotionals" %}
-                                {% if childimage and childimage != empty %}
-                                    {{ childimage }}
-                                {% elseif video and video != empty %}
-                                    {[ getImageFromVideoId id:'{{ video }}' resolution:'1000x500' ]}
-                                {% endif %}
-                            {% endif %}
-                        {% endcapture %}
-                        {% assign imageurl = imageurl | Trim %}
-                        {% capture imageoverlayurl %}{% endcapture %}
-                        {% capture imagealignment %}{% endcapture %}
-                        {% capture imageopacity %}{% endcapture %}
-                        {% capture grayscale %}{% endcapture %}
-                        {% capture backgroundvideourl %}{% endcapture %}
-                        {% capture lava %}{% endcapture %}
-                        {% capture ratio %}{% endcapture %}
-                        {% capture trimcopy %}{% endcapture %}
-                        {% capture linkcolor %}{% endcapture %}
-                        {% capture backgroundcolor %}{% endcapture %}
-                        {% capture linkurl %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ child.Id }}' ]}{% endcapture %}
-                        {% capture linktext %}{% if childType contains "Sermon" or childType contains "Series" %}Watch{% else %}Read{% endif %} {{ childType | Singularize }}{% endcapture %}
-
-                        {[ card id:'{{ id }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
-                    {% endfor %}
-                {% endcontentchannelitem %}
-
-            [[ enditem ]]
-        {% endfor %}
-    {[ endswiper ]}
-
-{% else %}
-    <div class="alert alert-danger">
-        <p>No parent content channel item id <strong>(cciid)</strong> parameter value was provided.</p>
-    </div>
-{% endif %}
+{% endfor %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/child-items-swiper.lava
@@ -1,4 +1,8 @@
 {% if cciid and cciid != empty %}
+    {% assign now = 'Now' | Date:'yyyy-MM-ddThh:mm:ss.000000' %}
+    {% assign startDate = Item | Attribute:'Dates','RawValue' | Split:',' | First %}
+    {% assign endDate = Item | Attribute:'Dates','RawValue' | Split:',' | Last %}
+
 
     {% comment %}
         Set current item slug so we can determine what the active slide should be
@@ -46,7 +50,14 @@
         {% endif %}
     {% endsql %}
 
-    {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+    {% comment %}
+        If we're between the beginning/ending dates of this collection, make the last item in the swiper active
+    {% endcomment %}
+    {% if now >= startDate and now < endDate %}
+        {% assign initialslide = results | Size | Minus:1 %}
+    {% else %}
+        {% assign initialslide = results | Where:'Slug', currentSlug | Select:'Index' %}
+    {% endif %}
 
     {% comment %}
         Now that we've setup our array of child item ids, we'll loop through them and get the content channel item that corresponds to each Id and generate our swiper element.

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/swiper.lava
@@ -76,6 +76,5 @@
   
   $(document).ready(function(){
     swiper.update();
-    swiper.slideTo(0, 50, false);
   });
 </script>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/wistia-embed.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/wistia-embed.lava
@@ -1,9 +1,11 @@
+{% if id and id != empty %}
 {% if CurrentPerson | HasRightsTo:'Edit' %}
 <div class="position-absolute top-zero right-zero push-top push-right bring-forward text-right">
     <a href="/video/{{ id }}" class="btn btn-sm btn-info push-half-bottom">About This Video</a><br>
     <a href="https://newspringchurch.wistia.com/medias/{{ id }}" target="_blank" class="btn btn-sm btn-info">Edit This Video</a>
 </div>
 {% endif %}
+
 <div class="wistia_responsive_wrapper push-bottom xs-push-half-bottom" style="height:100%;left:0;width:100%;">
     <div id="wistia_{{ id }}" class="wistia_embed rounded shadowed overflow-hidden">
         <div class="wistia_swatch hidden" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;">
@@ -45,3 +47,4 @@
         smallPlayButton: {{ showsmallplaybutton }} 
     }); 
 </script>
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/wistia-embed.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/wistia-embed.lava
@@ -4,7 +4,7 @@
     <a href="https://newspringchurch.wistia.com/medias/{{ id }}" target="_blank" class="btn btn-sm btn-info">Edit This Video</a>
 </div>
 {% endif %}
-<div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+<div class="wistia_responsive_wrapper push-bottom xs-push-half-bottom" style="height:100%;left:0;width:100%;">
     <div id="wistia_{{ id }}" class="wistia_embed rounded shadowed overflow-hidden">
         <div class="wistia_swatch hidden" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;">
             <img src="https://fast.wistia.com/embed/medias/{{ id }}/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" onload="this.parentNode.style.opacity=1;" />


### PR DESCRIPTION
## DESCRIPTION

This update changes the way the child items swiper works, in that if the current date/time falls between the collection's date range (current series), we make the most recent item the active one, instead of the first.

I also updated the wistia embed shortcode to do nothing if a video id is not present.

### How do I test this PR?

#### Current Series
https://brian-new.newspring.cc/sermons/the-life-giving-church

#### Past Series
https://brian-new.newspring.cc/sermons/teach-us-to-pray

## TODO

We'll need to update the `ChildItemsSwiper`, `Swiper` and `WistiaEmbed` shortcodes to point back to their corresponding lava templates post-deploy.

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
