### PR TITLE
Update Locations Pages to Use a Persisted Dataset

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
@@ -22,7 +22,7 @@
                 {% endif %}
             {% endif %}
             {% if servicetype == 'Fuse' %}
-                <br><a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top" target="_blank">Get Directions</a>
+                <br><a href="{{ getDirections }}" target="_blank">Get Directions</a>
                 <br>
             {% endif %}
             <br>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -1,44 +1,43 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Uppercase %}
-{% campus where:'Name == "{{ campusSlug }}"' iterator:'campuses' %}
-{% for campus in campuses %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+{% assign campuses = 'campuses' | PersistedDataset %}
+{% assign campus = campuses | Where:'Name', campusSlug | First %}
 
-    {% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %} in {{ campus.Name }}, SC | Locations | {% if servicetype == 'Fuse' %} Fuse | {% endif %}{{ 'Global' | Page:'SiteName' }}{% endcapture %}
+{% comment %}
+{% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %} in {{ campus.Name }}, SC | Locations | {% if servicetype == 'Fuse' %} Fuse | {% endif %}{{ 'Global' | Page:'SiteName' }}{% endcapture %}
+{% endcomment %}
+{% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}{% if campus.Name != 'Eastlan' %} in {{ campus.Name }}, SC{% else %} - {{ campus.Name }}{% endif %} | Locations{% if servicetype == 'Fuse' %} | Fuse{% endif %} | {{ 'Global' | Attribute:'OrganizationName' }}{% endcapture %}
+{{ title | SetPageTitle:'PageTitle' }}
+{{ title | SetPageTitle:'BrowserTitle' }}
 
-    {{ title | SetPageTitle:'PageTitle' }}
-    {{ title | SetPageTitle:'BrowserTitle' }}
+{% assign fuseImageUrl = campus.FuseLandscapeImage %}
+{% assign nsImageUrl = campus.LandscapeImage %}
 
-    {% assign fuseImageUrl = campus | Attribute:'FuseImageLandscape','Url' %}
-    {% assign nsImageUrl = campus | Attribute:'ImageLandscape','Url' %}
+{% assign fuseDirectionsUrl = campus.FuseGetDirectionsURL %}
+{% assign nsDirectionsUrl = campus.GetDirectionsURL %}
 
-    {% assign fuseDirectionsUrl = campus | Attribute:'FuseGetDirectionsURL','RawValue' %}
-    {% assign nsDirectionsUrl = campus | Attribute:'GetDirectionsURL','RawValue' %}
+{% capture id %}{% endcapture %}
+{% capture title %}{% if servicetype != 'Fuse' %}{{ 'Global' | Attribute:'OrganizationName' }}{% else %}Fuse Student Ministry{% endif %}{% endcapture %}
+{% capture titlesize %}{% endcapture %}
+{% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name }}, SC</h3>{% endcapture %}
+{% capture textalignment %}{% endcapture %}
+{% capture label %}{% endcapture %}
+{% capture subtitle %}{% endcapture %}
+{% capture imageurl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
+{% capture imageoverlayurl %}{% endcapture %}
+{% capture imagealignment %}{% endcapture %}
+{% capture imageopacity %}.4{% endcapture %}
+{% capture imageflip %}{% endcapture %}
+{% capture imageblur %}{% endcapture %}
+{% capture grayscale %}{% endcapture %}
+{% capture backgroundvideourl %}{% endcapture %}
+{% capture lava %}{% endcapture %}
+{% capture video %}{% endcapture %}
+{% capture ratio %}thin{% endcapture %}
+{% capture trimcopy %}{% endcapture %}
+{% capture linkcolor %}{% endcapture %}
+{% capture backgroundcolor %}#303030{% endcapture %}
+{% assign linkurl = "" %}
+{% assign linktext = "" %}
+{% capture hideforegroundelements %}{% endcapture %}
 
-    {% capture id %}{% endcapture %}
-    {% capture title %}{% if servicetype != 'Fuse' %}{{ 'Global' | Attribute:'OrganizationName' }}{% else %}Fuse Student Ministry{% endif %}{% endcapture %}
-    {% capture titlesize %}{% endcapture %}
-    {% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name }}, SC</h3>{% endcapture %}
-    {% capture textalignment %}{% endcapture %}
-    {% capture label %}{% endcapture %}
-    {% capture subtitle %}{% endcapture %}
-    {% capture imageurl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
-    {% capture imageoverlayurl %}{% endcapture %}
-    {% capture imagealignment %}{% endcapture %}
-    {% capture imageopacity %}.4{% endcapture %}
-    {% capture imageflip %}{% endcapture %}
-    {% capture imageblur %}{% endcapture %}
-    {% capture grayscale %}{% endcapture %}
-    {% capture backgroundvideourl %}{% endcapture %}
-    {% capture lava %}{% endcapture %}
-    {% capture video %}{% endcapture %}
-    {% capture ratio %}thin{% endcapture %}
-    {% capture trimcopy %}{% endcapture %}
-    {% capture linkcolor %}{% endcapture %}
-    {% capture backgroundcolor %}#303030{% endcapture %}
-    {% assign linkurl = "" %}
-    {% assign linktext = "" %}
-    {% capture hideforegroundelements %}{% endcapture %}
-
-    {[ hero id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' ]}
-
-{% endfor %}
-{% endcampus %}
+{[ hero id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' ]}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -1,19 +1,11 @@
 {% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
-{% assign campuses = 'campuses' | PersistedDataset %}
-{% assign campus = campuses | Where:'Name', campusSlug | First %}
+{% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
-{% comment %}
-{% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %} in {{ campus.Name }}, SC | Locations | {% if servicetype == 'Fuse' %} Fuse | {% endif %}{{ 'Global' | Page:'SiteName' }}{% endcapture %}
-{% endcomment %}
 {% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}{% if campus.Name != 'Eastlan' %} in {{ campus.Name }}, SC{% else %} - {{ campus.Name }}{% endif %} | Locations{% if servicetype == 'Fuse' %} | Fuse{% endif %} | {{ 'Global' | Attribute:'OrganizationName' }}{% endcapture %}
-{{ title | SetPageTitle:'PageTitle' }}
-{{ title | SetPageTitle:'BrowserTitle' }}
+{{ title | SetPageTitle }}
 
 {% assign fuseImageUrl = campus.FuseLandscapeImage %}
 {% assign nsImageUrl = campus.LandscapeImage %}
-
-{% assign fuseDirectionsUrl = campus.FuseGetDirectionsURL %}
-{% assign nsDirectionsUrl = campus.GetDirectionsURL %}
 
 {% capture id %}{% endcapture %}
 {% capture title %}{% if servicetype != 'Fuse' %}{{ 'Global' | Attribute:'OrganizationName' }}{% else %}Fuse Student Ministry{% endif %}{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -1,6 +1,5 @@
 {% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
-{% assign campuses = 'campuses' | PersistedDataset %}
-{% assign campus = campuses | Where:'Name', campusSlug | First %}
+{% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 {% assign mailingAddress = campus.MailingAddress %}
 {% assign officeAddress = campus.OfficeAddress %}
 {% assign getDirections = campus.GetDirectionsURL %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -1,162 +1,157 @@
 {% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Uppercase %}
-{% campus where:'Name == "{{ campusSlug }}"' iterator:'campuses' %}
+{% assign campuses = 'campuses' | PersistedDataset %}
 {% for campus in campuses %}
 
-{% assign location = campus.Location %}
-{% assign mailingAddress = campus | Attribute:'MailingAddress','Object' %}
-{% assign officeAddress = campus | Attribute:'OfficeAddress','Object' %}
-{% assign getDirections = campus | Attribute:'GetDirectionsURL','RawValue' %}
+    {% assign location = campus.Location %}
+    {% assign mailingAddress = campus.MailingAddress %}
+    {% assign officeAddress = campus.OfficeAddress %}
+    {% assign getDirections = campus.GetDirectionsURL %}
 
-{% capture serviceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'NewSpring' ]}{% endcapture %}
-{% capture fuseServiceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'Fuse' ]}{% endcapture %}
+    {% capture serviceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'NewSpring' ]}{% endcapture %}
+    {% capture fuseServiceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'Fuse' ]}{% endcapture %}
 
-{% assign serviceTimes = serviceTimes | Trim %}
-{% assign fuseServiceTimes = fuseServiceTimes | Trim %}
+    {% assign serviceTimes = serviceTimes | Trim %}
+    {% assign fuseServiceTimes = fuseServiceTimes | Trim %}
 
-{[ section title:'' ]}
-
-<div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
-    <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
-        <h3 class="push-half-bottom">Sunday Gatherings</h3>
-        <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
-        <p class="lead">{{ serviceTimes }}
-        {% if getDirections != empty %}
-            <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
-        {% endif %}
-        </p>
-    </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
-        <h3 class="push-half-bottom">Fuse Student Ministry</h3>
-        <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
-        <p class="lead">{{ fuseServiceTimes }}</p>
-    </div>{% endif %}
-</div>
-{[ endsection ]}
-
-
-
-{[ section title:'' ]}
-<div class="row soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
-    <div class="col-xs-12 col-sm-12 col-md-4">
-        {% if location != empty %}
-            <h3 class="push-half-bottom">Campus Address</h3>
-            <p class="lead">
-                {{ location.Street1 }}<br>
-                {% if location.Street2 != empty %}
-                    {{ location.Street2 }}<br>
+    {[ section title:'' ]}
+        <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
+            <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
+                <h3 class="push-half-bottom">Sunday Gatherings</h3>
+                <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
+                <p class="lead">{{ serviceTimes }}
+                {% if getDirections != empty %}
+                    <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
                 {% endif %}
-                {{ location.City }}, {{ location.State }} {{ location.PostalCode | Slice: 0, 5 }}
-            </p>
-        {% endif %}
+                </p>
+            </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
+                <h3 class="push-half-bottom">Fuse Student Ministry</h3>
+                <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
+                <p class="lead">{{ fuseServiceTimes }}</p>
+            </div>{% endif %}
+        </div>
+    {[ endsection ]}
 
-        {% if officeAddress.Street1 != null and officeAddress.Street1 != '' and officeAddress.Street1 != location.Street1 %}
-            <h3 class="push-half-bottom">Office Address</h3>
-            <p class="lead"> 
-                {{ officeAddress.Street1 }}<br>
-                {% if officeAddress.Street2 != empty %}
-                    {{ officeAddress.Street2 }}<br>
+    {[ section title:'' ]}
+        <div class="row soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
+            <div class="col-xs-12 col-sm-12 col-md-4">
+                {% if location != empty %}
+                    <h3 class="push-half-bottom">Campus Address</h3>
+                    <p class="lead">
+                        {{ location.Street1 }}<br>
+                        {% if location.Street2 != empty %}
+                            {{ location.Street2 }}<br>
+                        {% endif %}
+                        {{ location.City }}, {{ location.State }} {{ location.PostalCode | Slice: 0, 5 }}
+                    </p>
                 {% endif %}
-                {{ officeAddress.City }}, {{ officeAddress.State }} {{ officeAddress.PostalCode | Slice: 0, 5 }}
-            </p>
-        {% endif %}
 
-        {% if mailingAddress.Street1 != null and mailingAddress.Street1 != '' and mailingAddress.Street1 != location.Street1 and mailingAddress.Street1 != officeAddress.Street1 %}
-            <h3 class="push-half-bottom">Mailing Address</h3>
-            <p class="lead">
-                {{ mailingAddress.Street1 }}<br>
-                {% if mailingAddress.Street2 != empty %}
-                    {{ mailingAddress.Street2 }}<br>
+                {% if officeAddress.Street1 != null and officeAddress.Street1 != '' and officeAddress.Street1 != location.Street1 %}
+                    <h3 class="push-half-bottom">Office Address</h3>
+                    <p class="lead"> 
+                        {{ officeAddress.Street1 }}<br>
+                        {% if officeAddress.Street2 != empty %}
+                            {{ officeAddress.Street2 }}<br>
+                        {% endif %}
+                        {{ officeAddress.City }}, {{ officeAddress.State }} {{ officeAddress.PostalCode | Slice: 0, 5 }}
+                    </p>
                 {% endif %}
-                {{ mailingAddress.City }}, {{ mailingAddress.State }} {{ mailingAddress.PostalCode | Slice: 0, 5 }}
-            </p>
+
+                {% if mailingAddress.Street1 != null and mailingAddress.Street1 != '' and mailingAddress.Street1 != location.Street1 and mailingAddress.Street1 != officeAddress.Street1 %}
+                    <h3 class="push-half-bottom">Mailing Address</h3>
+                    <p class="lead">
+                        {{ mailingAddress.Street1 }}<br>
+                        {% if mailingAddress.Street2 != empty %}
+                            {{ mailingAddress.Street2 }}<br>
+                        {% endif %}
+                        {{ mailingAddress.City }}, {{ mailingAddress.State }} {{ mailingAddress.PostalCode | Slice: 0, 5 }}
+                    </p>
+                {% endif %}
+
+            </div><div class="col-xs-12 col-sm-12 col-md-4">
+                <h3 class="push-half-bottom">Phone</h3>
+                <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>
+            </div><div class="col-xs-12 col-sm-12 col-md-4">
+                <h3 class="push-half-bottom">Email</h3>
+                <p class="lead"><a href="mailto:{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc">{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc</a></p>
+            </div>
+        </div>
+    {[ endsection ]}
+
+    {% if servicetype != 'Fuse' %}
+        {% assign placesId = campus.GooglePlacesId %}
+        {% assign markerImage = 'Global' | Attribute:'GoogleMapsMarkerImageActive','Url' %}
+        {% if placesId != null and placesId != '' %}
+
+            <script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ 'Global' | Attribute:'GoogleAPIKey' }}&libraries=places"></script>
+
+            <div id="map-canvas" class="ratio ratio-landscape xs-ratio-square push-bottom xs-push-half-bottom rounded shadowed overflow-hidden"></div>
+
+            <script>
+            function initialize() {
+                var map = new google.maps.Map(document.getElementById('map-canvas'), {
+                    center: new google.maps.LatLng(0, 0),
+                    zoom: 16,
+                    disableDefaultUI: true
+                });
+
+                var service = new google.maps.places.PlacesService(map);
+
+                service.getDetails({
+                    placeId: '{{ placesId }}'
+                }, function (place, status) {
+                    if (status === google.maps.places.PlacesServiceStatus.OK) {
+
+                        // Create marker
+                        var marker = new google.maps.Marker({
+                            map: map,
+                            position: place.geometry.location,
+                            icon: '{{ markerImage }}'
+                        });
+
+                        // Center map on place location
+                        map.setCenter(place.geometry.location);
+
+                    }
+                });
+            }
+
+            initialize();
+            </script>
+
         {% endif %}
-
-    </div><div class="col-xs-12 col-sm-12 col-md-4">
-        <h3 class="push-half-bottom">Phone</h3>
-        <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>
-    </div><div class="col-xs-12 col-sm-12 col-md-4">
-        <h3 class="push-half-bottom">Email</h3>
-        <p class="lead"><a href="mailto:{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc">{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc</a></p>
-    </div>
-</div>
-
-{[ endsection ]}
-
-{% if servicetype != 'Fuse' %}
-    {% assign placesId = campus | Attribute:'GooglePlacesId' %}
-    {% assign markerImage = 'Global' | Attribute:'GoogleMapsMarkerImageActive','Url' %}
-    {% if placesId != null and placesId != '' %}
-
-        <script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ 'Global' | Attribute:'GoogleAPIKey' }}&libraries=places"></script>
-
-        <div id="map-canvas" class="ratio ratio-landscape xs-ratio-square push-bottom xs-push-half-bottom rounded shadowed overflow-hidden"></div>
-
-        <script>
-        function initialize() {
-            var map = new google.maps.Map(document.getElementById('map-canvas'), {
-                center: new google.maps.LatLng(0, 0),
-                zoom: 16,
-                disableDefaultUI: true
-            });
-
-            var service = new google.maps.places.PlacesService(map);
-
-            service.getDetails({
-                placeId: '{{ placesId }}'
-            }, function (place, status) {
-                if (status === google.maps.places.PlacesServiceStatus.OK) {
-
-                    // Create marker
-                    var marker = new google.maps.Marker({
-                        map: map,
-                        position: place.geometry.location,
-                        icon: '{{ markerImage }}'
-                    });
-
-                    // Center map on place location
-                    map.setCenter(place.geometry.location);
-
-                }
-            });
-        }
-
-        initialize();
-        </script>
-
     {% endif %}
-{% endif %}
 
 
-{% if servicetype == 'NewSpring' %}
-    <script type="application/ld+json">
-    {
-    "@context": "http://schema.org/",
-    "@type": "Church",
-    "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
-    "logo":"{{ 'Global' | Attribute:'NewSpringLogoSquare','RawValue' }}",
-    "image": "{{ campus | Attribute:'ImageLandscape','Url' }}",
-    "description": "{{ 'Global' | Attribute:'OrganizationVision' }}",
-    "branchCode": "{{ campus.ShortCode }}",
-    "telephone":"+1{{ campus.PhoneNumber | Remove:'-' }}",
-    "additionalProperty": {
-        "@type": "PropertyValue",
-        "propertyID": "email",
-        "value":"{{ campus.Name | Remove:' ' | Downcase }}@newspring.cc"
-    },
-    "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "{{ campus.Location.Street1 }}{% if campus.Location.Street2 != empty %} {{ campus.Location.Street2 }}{% endif %}",
-        "addressLocality":"{{ campus.Location.City }}",
-        "addressRegion":"{{ campus.Location.State }}",
-        "postalCode":"{{ campus.Location.PostalCode | Slice:0,5 }}"
-    },
-    "latitude": "{{ campus.Location.Latitude }}",
-    "longitude": "{{ campus.Location.Longitude }}",
-    "url":"{{ 'Global' | Page:'Url' }}",
-    "isAccessibleForFree":"true",
-    "publicAccess":"true"
-    }
-    </script>
-{% endif %}
+    {% if servicetype == 'NewSpring' %}
+        <script type="application/ld+json">
+        {
+        "@context": "http://schema.org/",
+        "@type": "Church",
+        "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
+        "logo":"{{ 'Global' | Attribute:'NewSpringLogoSquare','RawValue' }}",
+        "image": "{{ campus.LandscapeImage }}",
+        "description": "{{ 'Global' | Attribute:'OrganizationVision' }}",
+        "branchCode": "{{ campus.ShortCode }}",
+        "telephone":"+1{{ campus.PhoneNumber | Remove:'-' }}",
+        "additionalProperty": {
+            "@type": "PropertyValue",
+            "propertyID": "email",
+            "value":"{{ campus.Name | Remove:' ' | Downcase }}@newspring.cc"
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "{{ campus.Location.Street1 }}{% if campus.Location.Street2 != empty %} {{ campus.Location.Street2 }}{% endif %}",
+            "addressLocality":"{{ campus.Location.City }}",
+            "addressRegion":"{{ campus.Location.State }}",
+            "postalCode":"{{ campus.Location.PostalCode | Slice:0,5 }}"
+        },
+        "latitude": "{{ campus.Location.Latitude }}",
+        "longitude": "{{ campus.Location.Longitude }}",
+        "url":"{{ 'Global' | Page:'Url' }}",
+        "isAccessibleForFree":"true",
+        "publicAccess":"true"
+        }
+        </script>
+    {% endif %}
 
 {% endfor %}
-{% endcampus %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -1,157 +1,153 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Uppercase %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
 {% assign campuses = 'campuses' | PersistedDataset %}
-{% for campus in campuses %}
+{% assign campus = campuses | Where:'Name', campusSlug | First %}
+{% assign mailingAddress = campus.MailingAddress %}
+{% assign officeAddress = campus.OfficeAddress %}
+{% assign getDirections = campus.GetDirectionsURL %}
 
-    {% assign location = campus.Location %}
-    {% assign mailingAddress = campus.MailingAddress %}
-    {% assign officeAddress = campus.OfficeAddress %}
-    {% assign getDirections = campus.GetDirectionsURL %}
+{% capture serviceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'NewSpring' ]}{% endcapture %}
+{% capture fuseServiceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'Fuse' ]}{% endcapture %}
 
-    {% capture serviceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'NewSpring' ]}{% endcapture %}
-    {% capture fuseServiceTimes %}{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'Fuse' ]}{% endcapture %}
+{% assign serviceTimes = serviceTimes | Trim %}
+{% assign fuseServiceTimes = fuseServiceTimes | Trim %}
 
-    {% assign serviceTimes = serviceTimes | Trim %}
-    {% assign fuseServiceTimes = fuseServiceTimes | Trim %}
+{[ section title:'' ]}
+    <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
+        <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
+            <h3 class="push-half-bottom">Sunday Gatherings</h3>
+            <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
+            <p class="lead">{{ serviceTimes }}
+            {% if getDirections != empty %}
+                <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
+            {% endif %}
+            </p>
+        </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
+            <h3 class="push-half-bottom">Fuse Student Ministry</h3>
+            <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
+            <p class="lead">{{ fuseServiceTimes }}</p>
+        </div>{% endif %}
+    </div>
+{[ endsection ]}
 
-    {[ section title:'' ]}
-        <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
-            <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
-                <h3 class="push-half-bottom">Sunday Gatherings</h3>
-                <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
-                <p class="lead">{{ serviceTimes }}
-                {% if getDirections != empty %}
-                    <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
-                {% endif %}
+{[ section title:'' ]}
+    <div class="row soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
+        <div class="col-xs-12 col-sm-12 col-md-4">
+            {% if location != empty %}
+                <h3 class="push-half-bottom">Campus Address</h3>
+                <p class="lead">
+                    {{ campus.LocationStreet1 }}<br>
+                    {% if campus.LocationStreet2 != empty %}
+                        {{ campus.LocationStreet2 }}<br>
+                    {% endif %}
+                    {{ campus.LocationCity }}, {{ campus.LocationState }} {{ campus.LocationPostalCode | Slice: 0, 5 }}
                 </p>
-            </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
-                <h3 class="push-half-bottom">Fuse Student Ministry</h3>
-                <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
-                <p class="lead">{{ fuseServiceTimes }}</p>
-            </div>{% endif %}
+            {% endif %}
+
+            {% if officeAddress.Street1 != null and officeAddress.Street1 != '' and officeAddress.Street1 != location.Street1 %}
+                <h3 class="push-half-bottom">Office Address</h3>
+                <p class="lead"> 
+                    {{ officeAddress.Street1 }}<br>
+                    {% if officeAddress.Street2 != empty %}
+                        {{ officeAddress.Street2 }}<br>
+                    {% endif %}
+                    {{ officeAddress.City }}, {{ officeAddress.State }} {{ officeAddress.PostalCode | Slice: 0, 5 }}
+                </p>
+            {% endif %}
+
+            {% if mailingAddress.Street1 != null and mailingAddress.Street1 != '' and mailingAddress.Street1 != location.Street1 and mailingAddress.Street1 != officeAddress.Street1 %}
+                <h3 class="push-half-bottom">Mailing Address</h3>
+                <p class="lead">
+                    {{ mailingAddress.Street1 }}<br>
+                    {% if mailingAddress.Street2 != empty %}
+                        {{ mailingAddress.Street2 }}<br>
+                    {% endif %}
+                    {{ mailingAddress.City }}, {{ mailingAddress.State }} {{ mailingAddress.PostalCode | Slice: 0, 5 }}
+                </p>
+            {% endif %}
+
+        </div><div class="col-xs-12 col-sm-12 col-md-4">
+            <h3 class="push-half-bottom">Phone</h3>
+            <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>
+        </div><div class="col-xs-12 col-sm-12 col-md-4">
+            <h3 class="push-half-bottom">Email</h3>
+            <p class="lead"><a href="mailto:{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc">{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc</a></p>
         </div>
-    {[ endsection ]}
+    </div>
+{[ endsection ]}
 
-    {[ section title:'' ]}
-        <div class="row soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
-            <div class="col-xs-12 col-sm-12 col-md-4">
-                {% if location != empty %}
-                    <h3 class="push-half-bottom">Campus Address</h3>
-                    <p class="lead">
-                        {{ location.Street1 }}<br>
-                        {% if location.Street2 != empty %}
-                            {{ location.Street2 }}<br>
-                        {% endif %}
-                        {{ location.City }}, {{ location.State }} {{ location.PostalCode | Slice: 0, 5 }}
-                    </p>
-                {% endif %}
+{% if servicetype != 'Fuse' %}
+    {% assign placesId = campus.GooglePlacesId %}
+    {% assign markerImage = 'Global' | Attribute:'GoogleMapsMarkerImageActive','Url' %}
+    {% if placesId != null and placesId != '' %}
 
-                {% if officeAddress.Street1 != null and officeAddress.Street1 != '' and officeAddress.Street1 != location.Street1 %}
-                    <h3 class="push-half-bottom">Office Address</h3>
-                    <p class="lead"> 
-                        {{ officeAddress.Street1 }}<br>
-                        {% if officeAddress.Street2 != empty %}
-                            {{ officeAddress.Street2 }}<br>
-                        {% endif %}
-                        {{ officeAddress.City }}, {{ officeAddress.State }} {{ officeAddress.PostalCode | Slice: 0, 5 }}
-                    </p>
-                {% endif %}
+        <script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ 'Global' | Attribute:'GoogleAPIKey' }}&libraries=places"></script>
 
-                {% if mailingAddress.Street1 != null and mailingAddress.Street1 != '' and mailingAddress.Street1 != location.Street1 and mailingAddress.Street1 != officeAddress.Street1 %}
-                    <h3 class="push-half-bottom">Mailing Address</h3>
-                    <p class="lead">
-                        {{ mailingAddress.Street1 }}<br>
-                        {% if mailingAddress.Street2 != empty %}
-                            {{ mailingAddress.Street2 }}<br>
-                        {% endif %}
-                        {{ mailingAddress.City }}, {{ mailingAddress.State }} {{ mailingAddress.PostalCode | Slice: 0, 5 }}
-                    </p>
-                {% endif %}
+        <div id="map-canvas" class="ratio ratio-landscape xs-ratio-square push-bottom xs-push-half-bottom rounded shadowed overflow-hidden"></div>
 
-            </div><div class="col-xs-12 col-sm-12 col-md-4">
-                <h3 class="push-half-bottom">Phone</h3>
-                <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>
-            </div><div class="col-xs-12 col-sm-12 col-md-4">
-                <h3 class="push-half-bottom">Email</h3>
-                <p class="lead"><a href="mailto:{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc">{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc</a></p>
-            </div>
-        </div>
-    {[ endsection ]}
+        <script>
+        function initialize() {
+            var map = new google.maps.Map(document.getElementById('map-canvas'), {
+                center: new google.maps.LatLng(0, 0),
+                zoom: 16,
+                disableDefaultUI: true
+            });
 
-    {% if servicetype != 'Fuse' %}
-        {% assign placesId = campus.GooglePlacesId %}
-        {% assign markerImage = 'Global' | Attribute:'GoogleMapsMarkerImageActive','Url' %}
-        {% if placesId != null and placesId != '' %}
+            var service = new google.maps.places.PlacesService(map);
 
-            <script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ 'Global' | Attribute:'GoogleAPIKey' }}&libraries=places"></script>
+            service.getDetails({
+                placeId: '{{ placesId }}'
+            }, function (place, status) {
+                if (status === google.maps.places.PlacesServiceStatus.OK) {
 
-            <div id="map-canvas" class="ratio ratio-landscape xs-ratio-square push-bottom xs-push-half-bottom rounded shadowed overflow-hidden"></div>
+                    // Create marker
+                    var marker = new google.maps.Marker({
+                        map: map,
+                        position: place.geometry.location,
+                        icon: '{{ markerImage }}'
+                    });
 
-            <script>
-            function initialize() {
-                var map = new google.maps.Map(document.getElementById('map-canvas'), {
-                    center: new google.maps.LatLng(0, 0),
-                    zoom: 16,
-                    disableDefaultUI: true
-                });
+                    // Center map on place location
+                    map.setCenter(place.geometry.location);
 
-                var service = new google.maps.places.PlacesService(map);
-
-                service.getDetails({
-                    placeId: '{{ placesId }}'
-                }, function (place, status) {
-                    if (status === google.maps.places.PlacesServiceStatus.OK) {
-
-                        // Create marker
-                        var marker = new google.maps.Marker({
-                            map: map,
-                            position: place.geometry.location,
-                            icon: '{{ markerImage }}'
-                        });
-
-                        // Center map on place location
-                        map.setCenter(place.geometry.location);
-
-                    }
-                });
-            }
-
-            initialize();
-            </script>
-
-        {% endif %}
-    {% endif %}
-
-
-    {% if servicetype == 'NewSpring' %}
-        <script type="application/ld+json">
-        {
-        "@context": "http://schema.org/",
-        "@type": "Church",
-        "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
-        "logo":"{{ 'Global' | Attribute:'NewSpringLogoSquare','RawValue' }}",
-        "image": "{{ campus.LandscapeImage }}",
-        "description": "{{ 'Global' | Attribute:'OrganizationVision' }}",
-        "branchCode": "{{ campus.ShortCode }}",
-        "telephone":"+1{{ campus.PhoneNumber | Remove:'-' }}",
-        "additionalProperty": {
-            "@type": "PropertyValue",
-            "propertyID": "email",
-            "value":"{{ campus.Name | Remove:' ' | Downcase }}@newspring.cc"
-        },
-        "address": {
-            "@type": "PostalAddress",
-            "streetAddress": "{{ campus.Location.Street1 }}{% if campus.Location.Street2 != empty %} {{ campus.Location.Street2 }}{% endif %}",
-            "addressLocality":"{{ campus.Location.City }}",
-            "addressRegion":"{{ campus.Location.State }}",
-            "postalCode":"{{ campus.Location.PostalCode | Slice:0,5 }}"
-        },
-        "latitude": "{{ campus.Location.Latitude }}",
-        "longitude": "{{ campus.Location.Longitude }}",
-        "url":"{{ 'Global' | Page:'Url' }}",
-        "isAccessibleForFree":"true",
-        "publicAccess":"true"
+                }
+            });
         }
-        </script>
-    {% endif %}
 
-{% endfor %}
+        initialize();
+        </script>
+
+    {% endif %}
+{% endif %}
+
+
+{% if servicetype == 'NewSpring' %}
+    <script type="application/ld+json">
+    {
+    "@context": "http://schema.org/",
+    "@type": "Church",
+    "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
+    "logo":"{{ 'Global' | Attribute:'NewSpringLogoSquare','RawValue' }}",
+    "image": "{{ campus.LandscapeImage }}",
+    "description": "{{ 'Global' | Attribute:'OrganizationVision' }}",
+    "branchCode": "{{ campus.ShortCode }}",
+    "telephone":"+1{{ campus.PhoneNumber | Remove:'-' }}",
+    "additionalProperty": {
+        "@type": "PropertyValue",
+        "propertyID": "email",
+        "value":"{{ campus.Name | Remove:' ' | Downcase }}@newspring.cc"
+    },
+    "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "{{ campus.Location.Street1 }}{% if campus.Location.Street2 != empty %} {{ campus.Location.Street2 }}{% endif %}",
+        "addressLocality":"{{ campus.Location.City }}",
+        "addressRegion":"{{ campus.Location.State }}",
+        "postalCode":"{{ campus.Location.PostalCode | Slice:0,5 }}"
+    },
+    "latitude": "{{ campus.Location.Latitude }}",
+    "longitude": "{{ campus.Location.Longitude }}",
+    "url":"{{ 'Global' | Page:'Url' }}",
+    "isAccessibleForFree":"true",
+    "publicAccess":"true"
+    }
+    </script>
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -18,7 +18,7 @@
             <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
             <p class="lead">{{ serviceTimes }}
             {% if getDirections != empty %}
-                <a href="{{ getDirections }}" class="btn btn-primary btn-sm push-half-top">Get Directions</a>
+                <a href="{{ getDirections }}" >Get Directions</a>
             {% endif %}
             </p>
         </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -11,7 +11,7 @@
 {% if campus.campusStaff != empty %}
 {[ section title:'{{ campus.Name }} Staff' ]}
         
-    {% if leader != empty %}
+    {% if leader != null %}
     <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
         <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
             <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -1,6 +1,5 @@
 {% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
-{% assign campuses = 'campuses' | PersistedDataset %}
-{% assign campus = campuses | Where:'Name', campusSlug | First %}
+{% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
 {% if servicetype == 'Fuse' %}
     {% assign leader = campus.FusePastorPersonId | PersonById %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -1,54 +1,45 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Uppercase %}
-{% campus where:'Name == "{{ campusSlug }}"' iterator:'campuses' %}
-{% for campus in campuses %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+{% assign campuses = 'campuses' | PersistedDataset %}
+{% assign campus = campuses | Where:'Name', campusSlug | First %}
 
-    {% if servicetype == 'Fuse' %}
-        {% assign leader = campus | Attribute:'FusePastor','Object' %}
-    {% else %}
-        {% assign leader = campus.LeaderPersonAliasId | PersonByAliasId %}
-    {% endif %}
+{% if servicetype == 'Fuse' %}
+    {% assign leader = campus.FusePastorPersonId | PersonById %}
+{% else %}
+    {% assign leader = campus.CampusPastorPersonId | PersonById %}
+{% endif %}
 
-    {% group where:'ParentGroupId == 1528254 && Name == "{{ campus.Name }}"' iterator:'groups' %}
-        {% for group in groups %}
-            {% assign campusStaff =  group.Members | Select:'Person' | Sort:'LastName' %}
-        {% endfor %}
-    {% endgroup %}
-
-    {% if campusStaff != empty %}
-    {[ section title:'{{ campus.Name }} Staff' ]}
+{% if campus.campusStaff != empty %}
+{[ section title:'{{ campus.Name }} Staff' ]}
         
-        {% if leader != empty %}
-        <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
-            <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
-                <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
-            </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
-                <div class="soft-sides xs-hard">
-                    <h3 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
-                    <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
-                    <p>{{ leader | Attribute:'StaffBio' }}</p>
-                    <p><a href="mailto:{{ leader | Attribute:'StaffEmail' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
-                </div>
+    {% if leader != empty %}
+    <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
+        <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
+            <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
+        </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
+            <div class="soft-sides xs-hard">
+                <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
+                <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
+                <p>{{ leader | Attribute:'StaffBio' }}</p>
+                <p><a href="mailto:{{ leader | Attribute:'StaffEmail' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
             </div>
         </div>
-        {% endif %}
-
-        <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
-
-            {% for person in campusStaff %}{% assign staffTitle = person | Attribute:'StaffTitle' %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom  {% if person.FullName == leader.FullName %}hidden{% endif %}">
-
-                {[ user imageurl:'{{ person | Attribute:'StaffImage','Url' }}' title:'{{ person.FullName }}' subtitle:'{{ staffTitle | Replace:"'","’" }}' linkurl:'mailto:{{ person | Attribute:'StaffEmail' }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
-
-            </div>{% endfor %}
-        </div>
-
-        <style>
-            #staff .ratio-square {
-                margin: 0 auto;
-            }
-        </style>
-
-    {[ endsection ]}
+    </div>
     {% endif %}
 
-{% endfor %}
-{% endcampus %}
+    <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
+
+        {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom  {% if person.FullName == leader.FullName %}hidden{% endif %}">
+
+            {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'mailto:{{ person.StaffEmail }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
+
+        </div>{% endfor %}
+    </div>
+
+    <style>
+        #staff .ratio-square {
+            margin: 0 auto;
+        }
+    </style>
+
+{[ endsection ]}
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
@@ -1,21 +1,17 @@
 <div id="locations">
 {[ swiper title:'Find a Location' subtitle:'Swipe to Discover More' ]}
-
-    <!-- Slides -->
-    {% assign campuses = 'campuses' | PersistedDataset %}
-    {% for campus in campuses %}
-      {% assign directionsURL = campus.GetDirectionsURL %}
-      {% assign fuseDirectionsUrl = campus.FuseGetDirectionsURL %}
-      [[ item data:'data-latlon="{{ campus.Location.Latitude }},{{ campus.Location.Longitude }}"' ]]
-        {% assign nsImageUrl = campus.LandscapeImage %}
-        {% assign fuseImageUrl = campus.FuseLandscapeImage %}
-        {% capture campusImageUrl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
-        {% capture content %}
-          <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
-        {% endcapture %}
-        {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
-      [[ enditem ]]
-    {% endfor %}
-    
+  <!-- Slides -->
+  {% assign campuses = 'campuses' | PersistedDataset %}
+  {% for campus in campuses %}
+    [[ item data:'data-latlon="{{ campus.LocationLatitude }},{{ campus.LocationLongitude }}"' ]]
+      {% assign nsImageUrl = campus.LandscapeImage %}
+      {% assign fuseImageUrl = campus.FuseLandscapeImage %}
+      {% capture campusImageUrl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
+      {% capture content %}
+        <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
+      {% endcapture %}
+      {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
+    [[ enditem ]]
+  {% endfor %}
 {[ endswiper ]}
 </div>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
@@ -2,25 +2,20 @@
 {[ swiper title:'Find a Location' subtitle:'Swipe to Discover More' ]}
 
     <!-- Slides -->
-    {% campus where:'IsActive == true && Public == true' sort:'Name, asc' iterator:'campuses' %}
-        {% for campus in campuses %}
-            {% assign directionsURL = campus | Attribute:'GetDirectionsURL','RawValue' %}
-            {% assign fuseDirectionsUrl = campus | Attribute:'FuseGetDirectionsURL','RawValue' %}
-            
-            [[ item data:'data-latlon="{{ campus.Location.Latitude }},{{ campus.Location.Longitude }}"' ]]
-                {% assign nsImageUrl = campus | Attribute:'ImageLandscape' %}
-                {% assign fuseImageUrl = campus | Attribute:'FuseImageLandscape' %}
-                {% capture campusImageUrl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
-
-                {% capture content %}
-                    <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
-                {% endcapture %}
-            
-                {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
-                
-            [[ enditem ]]
-        {% endfor %}
-    {% endcampus %}
+    {% assign campuses = 'campuses' | PersistedDataset %}
+    {% for campus in campuses %}
+      {% assign directionsURL = campus.GetDirectionsURL %}
+      {% assign fuseDirectionsUrl = campus.FuseGetDirectionsURL %}
+      [[ item data:'data-latlon="{{ campus.Location.Latitude }},{{ campus.Location.Longitude }}"' ]]
+        {% assign nsImageUrl = campus.LandscapeImage %}
+        {% assign fuseImageUrl = campus.FuseLandscapeImage %}
+        {% capture campusImageUrl %}{% if fuseImageUrl and fuseImageUrl != empty and servicetype == 'Fuse' %}{{ fuseImageUrl }}{% else %}{{ nsImageUrl }}{% endif %}{% endcapture %}
+        {% capture content %}
+          <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
+        {% endcapture %}
+        {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
+      [[ enditem ]]
+    {% endfor %}
     
 {[ endswiper ]}
 </div>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR: 
* Updates location lava templates to pull their data from a persisted dataset.
* Changes the "Get Directions" buttons to be regular links. 

### How do I test this PR?
* Copy the persisted dataset from https://rich-rock.newspring.cc/page/2396?PersistedDatasetId=1 and create or update the Campus dataset in your database.
* Pull this code and then run your site.
* Look at the locations pages ( `/locations`, `/locations/{campus}`, `/fuse/locations`, and `/fuse/locations/{campus}` and make sure that everything loads and looks correct.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
