### PR TITLE
Added the ability to hide tags from the card list lava layout shortcode

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
@@ -80,7 +80,7 @@
         	    {% assign collectionurl = '' %}
     	    {% endif %}
 
-            {[ card guid:'{{ guid }}' cciid:'{{ cciid }}' id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+            {[ card guid:'{{ guid }}' cciid:'{{ cciid }}' id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' showtags:'{{ showtags }}' ]}
 
     	</div>{% endfor -%}
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/card.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/card.lava
@@ -65,7 +65,9 @@
             <p class="sans-serif stronger letter-spacing-condensed text-uppercase text-gray-light push-half-bottom"><small>{{ subtitle }}</small></p>
         {% endif %}
 
-        {[ tags guid:'{{ guid }}' ]}
+        {% if showtags != 'false' %}
+            {[ tags guid:'{{ guid }}' ]}
+        {% endif %}
 
         {% if content != null and content != '' %}
             {% if trimcopy != null and trimcopy != '' %}


### PR DESCRIPTION
## DESCRIPTION

This PR adds a shortcode parameter to the card list shortcode that enables us to hide topic tags in specific instances. This is necessary on newspringnetwork.com/resources/teaching as...

1. It's super unclear that when you click a topic tag that you switch from network to newspring.cc
2. The links on the topic page are then to broken pages (IE newspringnetwork.com/articles/{Slug}

## TESTING

1. Pull down this branch.
2. Make sure the Card List and Card lava shortcodes are actually pointing to their lava template files.
3. Go to a page that has a cardList shortcode on it (https://rich.newspringnetwork.com/resources/teaching), and add the `showtags:'false'` parameter
4. Topic tags should not be visible on the cards within the card list.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
