### PR TITLE
Adding the ability to do comparisons to previous value for metric dashboards

### DIFF
--- a/Rock.Rest/Controllers/MetricsController.partial.cs
+++ b/Rock.Rest/Controllers/MetricsController.partial.cs
@@ -102,6 +102,17 @@ namespace Rock.Rest.Controllers
                         metricYTDData.LastValue = lastMetricCumulativeValues.Sum( a => a.YValue ).HasValue ? Math.Round( lastMetricCumulativeValues.Sum( a => a.YValue ).Value, roundYValues ? 0 : 2 ) : (decimal?)null;
                     }
 
+                    var previousMetricValue = qryMeasureValues.OrderByDescending(a => a.MetricValueDateTime).Skip(1).FirstOrDefault();
+                    if ( previousMetricValue != null )
+                    {
+                        metricYTDData.PreviousValueDate = previousMetricValue.MetricValueDateTime.HasValue ? previousMetricValue.MetricValueDateTime.Value.Date : DateTime.MinValue;
+
+                        // get a sum of the values that for whole 24 hour day of the previous Date
+                        DateTime previousValueDateEnd = metricYTDData.PreviousValueDate.AddDays(1);
+                        var previousMetricCumulativeValues = qryMeasureValues.Where(a => a.MetricValueDateTime.HasValue && a.MetricValueDateTime.Value >= metricYTDData.PreviousValueDate && a.MetricValueDateTime.Value < previousValueDateEnd);
+                        metricYTDData.PreviousValue = previousMetricCumulativeValues.Sum(a => a.YValue).HasValue ? Math.Round(previousMetricCumulativeValues.Sum(a => a.YValue).Value, roundYValues ? 0 : 2) : (decimal?)null;
+                    }
+
                     decimal? sum = qryMeasureValues.Sum( a => a.YValue );
                     metricYTDData.CumulativeValue = sum.HasValue ? Math.Round( sum.Value, roundYValues ? 0 : 2 ) : (decimal?)null;
 
@@ -187,6 +198,24 @@ namespace Rock.Rest.Controllers
         /// </value>
         [DataMember]
         public DateTime LastValueDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the previous value.
+        /// </summary>
+        /// <value>
+        /// The last value.
+        /// </value>
+        [DataMember]
+        public object PreviousValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last value date.
+        /// </summary>
+        /// <value>
+        /// The last value date.
+        /// </value>
+        [DataMember]
+        public DateTime PreviousValueDate { get; set; }
 
         /// <summary>
         /// Gets or sets the cumulative value.


### PR DESCRIPTION
### What does this PR do, or why is it needed?
This change simply surfaces the value and date of the previous metric value to the lava of the liquid dashboard widget, for determining comparisons.

I've opened a core PR for this as well: https://github.com/SparkDevNetwork/Rock/pull/4163

### How do I test this PR?
1. Pull down the branch & build it
2. Put the liquid dashboard widget block on any page, select any metric with values, and add the following lava" `{{ metric | ToJSON }}`
3. See the `PreviousValue` and `PreviousValueDate` properties listed

![image](https://user-images.githubusercontent.com/2465823/78030132-a0ffd780-732f-11ea-8468-9bfb2da27efe.png)

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
