### PR TITLE
Improved Performance of Scripture Lava

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -107,13 +107,13 @@
             {% if label and label != empty %}
                 <p><small class="label bg-gray-light sans-serif letter-spacing-condensed circular">{{ label }}</small></p>
             {% endif %}
-            
+
             <h1 class="h2 xs-h3 push-half-bottom xs-push-half-bottom">{{ Item.Title }}</h1>
 
             {% if parentItem and parentItem != empty %}
                 <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentItem.Title }}{% if parentPermalink != empty %}</a>{% endif %}</small>
             {% endif %}
-            
+
             {% if subtitle != empty %}
                 <p class="lead text-gray-light"><i>{{ subtitle }}</i></p>
             {% endif %}
@@ -123,13 +123,15 @@
             {% if communicatorNames and communicatorNames != empty and communicatorNames != '' %}
                 <p class="stronger">{{ communicatorNames | Trim }}</p>
             {% endif %}
-            
+
             {% if imageUrl and imageUrl != empty %}
                 <div class="ratio-landscape background-cover push-bottom rounded" style="background-image:url('{{ imageUrl }}');"></div>
             {% endif %}
 
-            {% assign scripturesguid = Item | Attribute:'Scriptures','RawValue' %}
-            {% capture scripturereferences %}{[ scriptureReferences guid:'{{ scripturesguid }}' ]}{% endcapture %}
+            {% capture scripturesString %}{{ item | Attribute:'Scriptures' }}{% endcapture %}
+            {% assign scripturesObject = scripturesString | FromJSON %}
+
+            {% capture scripturereferences %}{% for scripture in scripturesObject.Attributes %}{{ scripture.Book }} {{ scripture.Reference }}{% unless forloop.last %}, {% endunless %}{% endfor %}{% endcapture %}
             {% assign scripturereferences = scripturereferences | Trim %}
 
             {%  if scripturereferences and scripturereferences != empty %}
@@ -138,7 +140,7 @@
                     <p class="lead">{{ scripturereferences }}</p>
                 </div>
             {% endif %}
-            
+
             {% if video != empty %}
                 <p id="video" class="text-center">
                     {[ wistiaButton id:'{{ video }}' buttontext:'' buttonclasses:'' contentchannelitemid:'{{ Item.Id }}' entitytypeid:'' entityid:'' ]}
@@ -147,7 +149,7 @@
             {% endif %}
 
             {{ Item.Content }}
-            
+
             <div class="push-bottom">
                 <div class="row row-condensed">
                     <div class="col-md-12 col-sm-12 col-xs-12">
@@ -181,7 +183,7 @@
 
 
 
-            
+
             {% capture itemToken %}cci{{ Item.ContentChannelId }}{{ Item.Id }}{% endcapture %}
             {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
 
@@ -197,9 +199,9 @@
             {%- endcapture -%}
             {% assign sharehashtag = '' %}
 
-            
+
             {[ modalShare ]}
-            
+
             {% if isDateVisible == 'True' %}
                 {% if tags and tags != empty %}
                     <div class="row">


### PR DESCRIPTION
## DESCRIPTION

This PR removes all references to the `scriptureReferences` lava shortcode that was significantly inefficient. To replace it, we will update the `Formatted Lava` attribute of the `Scriptures` attribute matrix template to output the values from the matrix as a consumable JSON object.

This is the updated `Formatted Lava` code that we'll be using for the attribute matrix template going forward:

`{%- capture attributeValuesObject %}{% if AttributeMatrixItems != empty -%}{
    "Attributes": [{%- for attributeMatrixItem in AttributeMatrixItems -%}{
        {%- for itemAttribute in ItemAttributes -%}
            {% assign av = attributeMatrixItem | Attribute:itemAttribute.Key | Trim %}
            "{{ itemAttribute.Key }}": "{{ av }}"{% if forloop.last != true %},{% endif %}
        {%- endfor -%}
    }{% if forloop.last != true %},{% endif %}{%- endfor -%}]
}{% endif %}{%- endcapture -%}{{ attributeValuesObject | Trim }}`

### How do I test this PR?
To test this PR, you'll need to... 
1. Update the `Formatted Lava` attribute of the `Scriptures` attribute matrix template in your local database.
2. Checkout this branch
3. Test any devotional on newspring.cc that has scripture references associated with it.

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
