### PR TITLE
updated content channel items datasets lava template with correct att…

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/DATASETS/content-channel-items-by-channel.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/DATASETS/content-channel-items-by-channel.lava
@@ -75,7 +75,7 @@
             ON pd.Id = av.Value
             WHERE ccia.ContentChannelItemId = {{ item.Id }}
             AND cci.ContentChannelId = {{ childchannelid }}
-            AND av.AttributeId = 105665
+            AND av.AttributeId = 107096
             {% if childItemsManuallyOrdered == 'true' %}
               ORDER BY ccia.[Order]
             {% else %}
@@ -104,7 +104,7 @@
             ON pd.Id = av.Value
             WHERE ccia.ChildContentChannelItemId = {{ item.Id }}
             AND cci.ContentChannelId = {{ parentchannelid }}
-            AND av.AttributeId = 105665
+            AND av.AttributeId = 107096
             ORDER BY ccia.[Order]
           {%- endsql -%}
         {%- endif -%}
@@ -126,7 +126,7 @@
                   JOIN PersistedDataset pd
                   ON av.Value = pd.Id
                   WHERE av.EntityId = cci2.ContentChannelId
-                  AND av.AttributeId = 105665
+                  AND av.AttributeId = 107096
               ) 'Dataset'
           FROM ContentChannelItem cci
           JOIN TaggedItem ti


### PR DESCRIPTION
## DESCRIPTION

This PR updates the "content channel items by channel" datasets lava template with the correct attribute Id for content channel dataset attribute for production. Because this attribute wasn't created on prod first and copied down, it initially was a different Id on various environments. As backups are pulled from prod onto our other environments, this Id will be consistent everywhere.

### How do I test this PR?

Content Channel Item Persisted Datasets should manually build successfully.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
