### PR TITLE
Updated locations pages so they redirect to 404 if the url doesn't match a campus

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -1,5 +1,10 @@
 {% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
+
+{% if campus == null %}
+  {{ '/page-not-found' | PageRedirect }}
+{% endif %}
 
 {% capture title %}{% if servicetype == 'Fuse' %}Fuse Student Ministry{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}{% if campus.Name != 'Eastlan' %} in {{ campus.Name }}, SC{% else %} - {{ campus.Name }}{% endif %} | Locations{% if servicetype == 'Fuse' %} | Fuse{% endif %} | {{ 'Global' | Attribute:'OrganizationName' }}{% endcapture %}
 {{ title | SetPageTitle }}


### PR DESCRIPTION
## DESCRIPTION

This change fixes an issue where locations page urls that don't match an actual campus wouldn't 404.

### How do I test this PR?

The following URLs should redirect to 404:
- https://brian-new.newspring.cc/locations/onsdg
- https://brian-new.newspring.cc/fuse/locations/kjnasgdo

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
