### PR TITLE
Added Weekly Dashboard Totals by Campus

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/weekly-metrics-dashboard.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/weekly-metrics-dashboard.lava
@@ -311,6 +311,49 @@
 </div>
 
 
+
+{% if currentCampus == empty %}
+    {[ rockCard title:'Attendance Totals By Campus' iconclass:'' ]}
+        <div class="table-responsive">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Campus</th>
+                        <th>Services</th>
+                        <th>Adult Attendance</th>
+                        <th>KidSpring</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for campus in campuses %}
+                        {% assign adultCampusValues = adultAttendanceValues | Where:'Date',currentWeekString | Where:'CampusId',campus.Id %}
+                        {% assign schedules = valuesObject | Where:'Date',currentWeekString | First | Property:'Schedules' %}
+
+                        {% assign campusAdultTotal = 0 %}
+                        {% assign campusKidSpringTotal = 0 %}
+
+                        {% for value in adultCampusValues %}
+                            {% assign campusAdultTotal = campusAdultTotal | Plus:value.AdultAttendance %}
+                        {% endfor %}
+
+                        {% for schedule in schedules %}
+                            {% assign ksvalue = schedule.Campuses | Where:'Name',campus.Name | First | Property:'KidSpringAttendance' %}
+                            {% assign campusKidSpringTotal = campusKidSpringTotal | Plus:ksvalue %}
+                        {% endfor %}
+
+                        <tr>
+                            <td>{{ campus.ShortCode }}</td>
+                            <td>{{ adultAttendanceValues | Where:'Date',currentWeekString | Where:'CampusId',campus.Id | Size }}</td>
+                            <td>{{ campusAdultTotal | Format:'###,###,###' }}</td>
+                            <td>{{ campusKidSpringTotal | Format:'###,###,###' }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {[ endrockCard ]}
+{% endif %}
+
 {[ rockCard title:'Total Attendance - Last 12 Weeks' iconclass:'' ]}
     <canvas id="myChart" width="400" height="150"></canvas>
 {[ endrockCard ]}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR adds a chart to the weekly dashboard that displays the total numbers, broken down by campus.

### How do I test this PR?
- Pull down this branch
- Update connectionstrings to have `Initial Catalog` value of `Brian`
- Visit `/page/2709?date=2020-03-08`
- Verify that extra chart should only be visible when a campus is not selected from the campus selector
- Revert changes to connectionstrings back to what it was before

![image](https://user-images.githubusercontent.com/2465823/88548692-6eb86b00-cfed-11ea-96a8-246353fafcdf.png)

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
