### PR TITLE
Added Lava to Log Interactions for Content

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
@@ -15,6 +15,16 @@
     {% endif %}
 {% endif %}
 
+{% comment %}
+    Write content channel item interaction
+{% endcomment %}
+{% assign currentUrl = 'Global'| Page:'Url' %}
+{% assign siteId = 'Global' | Page:'SiteId' %}
+{% assign source = 'Global'| PageParameter:'utm_source' %}
+{% assign medium = 'Global'| PageParameter:'utm_medium' %}
+{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+
 {% assign pagePath = 'Global' | Page:'Path' %}
 {% assign orgName = 'Global' | Attribute:'OrganizationName' %}
 {% assign channelName = Item.ContentType | Pluralize %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -26,6 +26,16 @@
 {% endif %}
 
 {% comment %}
+    Write content channel item interaction
+{% endcomment %}
+{% assign currentUrl = 'Global'| Page:'Url' %}
+{% assign siteId = 'Global' | Page:'SiteId' %}
+{% assign source = 'Global'| PageParameter:'utm_source' %}
+{% assign medium = 'Global'| PageParameter:'utm_medium' %}
+{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+
+{% comment %}
     Set item properties
 {% endcomment %}
 {% capture date %}{[ formatDate date:'{{ Item.PublishDateTime }}' ]}{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/network-resource-collection.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/network-resource-collection.lava
@@ -1,3 +1,13 @@
+{% comment %}
+    Write content channel item interaction
+{% endcomment %}
+{% assign currentUrl = 'Global'| Page:'Url' %}
+{% assign siteId = 'Global' | Page:'SiteId' %}
+{% assign source = 'Global'| PageParameter:'utm_source' %}
+{% assign medium = 'Global'| PageParameter:'utm_medium' %}
+{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+
 {% assign category = Item.Category %}
 {% assign currentUrl = 'Global' | Page:'Url' | Url:'pathandquery' %}
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
@@ -15,6 +15,15 @@
     {% endif %}
 {% endif %}
 
+{% comment %}
+    Write content channel item interaction
+{% endcomment %}
+{% assign currentUrl = 'Global'| Page:'Url' %}
+{% assign siteId = 'Global' | Page:'SiteId' %}
+{% assign source = 'Global'| PageParameter:'utm_source' %}
+{% assign medium = 'Global'| PageParameter:'utm_medium' %}
+{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
 
 {% assign parentChannelId = Item.ParentChannelId | AsInteger %}
 {% assign parent = Item.Parents | Where:'ChannelId', parentChannelId | First %}


### PR DESCRIPTION
## DESCRIPTION

This PR updates our lava templates that are used to display content from a single content channel item, and adds functionality to log a view interaction when the template is run.

### How do I test this PR?

1. Pull down this branch
2. Update connectionstrings to have an `Initial Catalog` value of `Brian`
3. To verify interactions, you can use the following query to see recent interactions for any component. Find a component in the interaction channel list, grab it's Id from the browser address bar, and use it in this query to see all of the interaction property values.

```
SELECT TOP 10 *
FROM Interaction i
WHERE i.InteractionComponentId = 679543
ORDER BY i.InteractionDateTime DESC
```

#### Comprehensive list of interaction channels to test:
- [x] NewSpring - Articles
- [x] NewSpring - Sermons
- [x] NewSpring - Sermon Series (newspring and network sites)
- [x] NewSpring - Stories
- [x] NewSpring - Studies
- [x] NewSpring - Devotionals
- [x] NewSpring - News
- [x] Fuse - Sermon Series (newspring and network sites)
- [x] Fuse - Sermons
- [x] Fuse - Studies
- [x] Fuse - Devotionals
- [x] KidSpring - Series (newspring and network sites)
- [x] KidSpring - Lessons
- [x] Worship - Albums (newspring and network sites)

4. For at least one interaction from each of the above channels...
- [ ]  `InteractionDateTime` should be present and accurate
- [ ]  `Operation` should be `View`
- [ ]  `PersonAliasId` should be the `PersonAliasId` of the person who viewed the content
- [ ]  `InteractionSessionId` should be present
- [ ]  `InteractionSummary` should describe the interaction appropriately
- [ ]  `InteractionData` should include the URL at which the interaction took place
- [ ]  `ChannelCustom1` should contain the `SiteId` where the interaction took place (22 for newspring.cc, 27 for newspringnetwork.com)

5. Revert connectionstrings back to its initial value

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
