### PR TITLE
Cherry Pick Asset Manager Fix

### DIFF
--- a/RockWeb/Scripts/Rock/Controls/assetManager.js
+++ b/RockWeb/Scripts/Rock/Controls/assetManager.js
@@ -47,6 +47,8 @@
                     $('.js-assetselect').addClass('aspNetDisabled');
                 }
 
+                $fileCheckboxes.removeAttr('checked');
+
                 // Can only add if either an asset or folder is selected
                 if ($selectFolder.val() === "" && $assetStorageId.val() === "-1") {
                     $createFolder.addClass('aspNetDisabled');


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
- (CMS) Fixed issue in Asset Manager file picker where the select button would not be active when re-opening the modal after selecting a file.

### How do I test this PR?

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
