### PR TITLE
Updated layout of metric entry block dropdowns so they don't get cut off on mobile

### DIFF
--- a/RockWeb/Blocks/Reporting/ServiceMetricsEntry.ascx
+++ b/RockWeb/Blocks/Reporting/ServiceMetricsEntry.ascx
@@ -27,10 +27,16 @@
 
             <asp:Panel ID="pnlMetrics" runat="server" Visible="false">
 
-                <div class="btn-group btn-group-justified margin-b-lg panel-settings-group" >
-                    <Rock:ButtonDropDownList ID="bddlCampus" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
-                    <Rock:ButtonDropDownList ID="bddlWeekend" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
-                    <Rock:ButtonDropDownList ID="bddlService" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
+                <div class="row text-center">
+                    <div class="col-md-4 col-sm-4 col-xs-12 margin-b-md">
+                        <Rock:ButtonDropDownList ID="bddlCampus" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
+                    </div>
+                    <div class="col-md-4 col-sm-4 col-xs-12 margin-b-md">
+                        <Rock:ButtonDropDownList ID="bddlWeekend" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
+                    </div>
+                    <div class="col-md-4 col-sm-4 col-xs-12 margin-b-md">
+                        <Rock:ButtonDropDownList ID="bddlService" runat="server" OnSelectionChanged="bddl_SelectionChanged" />
+                    </div>
                 </div>
 
                 <asp:ValidationSummary ID="vsDetails" runat="server" HeaderText="Please correct the following:" CssClass="alert alert-validation" />


### PR DESCRIPTION
## DESCRIPTION

This PR updates the layout of the core metrics entry block to prevent the dropdowns for Campus/Date/Schedule from getting cut off on phones.

### Before
![image](https://user-images.githubusercontent.com/2465823/90440275-f18c8d00-e0a4-11ea-8864-2f68aeaba240.png)

### After
![image](https://user-images.githubusercontent.com/2465823/90440197-d15cce00-e0a4-11ea-81b0-c9205a50d6a9.png)

### How do I test this PR?
- Pull down this branch
- Visit /sundaymetrics on the rock internal site on whatever environment you're testing in

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
