### PR TITLE
Group Leader Resources Simplification for Launch

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
@@ -256,73 +256,49 @@ ORDER BY g2.Name, p.LastName, p.NickName
 {% comment %}
   Group Leader Resources
 {% endcomment %}
-
-{% sql return:'resourceContentChannelItemIds' %}
-SELECT
-    cci.Id
-FROM ContentChannelItem cci
-JOIN AttributeValue av
-ON av.EntityId = cci.Id
-WHERE cci.ContentChannelId = 714 -- Group Resources Content Channel
-AND av.AttributeId = 109285 -- Group Types Content Channel Item Attribute
-AND av.Value IN (
-    SELECT
-        DISTINCT gt.Guid
-    FROM GroupMember gm
-    JOIN [Group] g
-    ON gm.GroupId = g.Id
-    JOIN GroupType gt
-    ON g.GroupTypeId = gt.Id
-    WHERE gm.PersonId = {{ personId }}
-    AND gt.Guid IN ({{ groupTypeGuids }})
-)
-{% endsql %}
-
-{% assign resourceIds = resourceContentChannelItemIds | Select:'Id' | Join:',' %}
-
 {% if groups != empty or leaders != empty or coaches != empty %}
-{% contentchannelitem ids:'{{ resourceIds }}' sort:'StartDateTime desc' iterator:'items' %}
-  {% if items and items != empty %}
-    <h2 class="h3 xs-h5 text-uppercase strongest push-top">Leader Resources</h2>
+  {% contentchannelitem where:'ContentChannelId == 714' limit:'3' sort:'StartDateTime desc' iterator:'items' %}
+    {% if items and items != empty %}
+      <h2 class="h3 xs-h5 text-uppercase strongest push-top">Leader Resources</h2>
 
-    <div class="row">
-      {% for item in items limit:3 %}<div class="col-lg-4 col-md-4 col-sm-6 col-xs-12 flush">
+      <div class="row">
+        {% for item in items limit:3 %}<div class="col-lg-4 col-md-4 col-sm-6 col-xs-12 flush">
 
-        {% assign fallbackImage = item.ContentChannel | Attribute:'ImageLandscape' %}
-        {% assign relatedItemGuid = item | Attribute:'RelatedEntry','RawValue' | WithFallback:'',null %}
-        {% assign format = item | Attribute:'ContentFormat' %}
-        {% assign verb = item | Attribute:'ContentFormat','Object' | Attribute:'Verb' %}
+          {% assign fallbackImage = item.ContentChannel | Attribute:'ImageLandscape' %}
+          {% assign relatedItemGuid = item | Attribute:'RelatedEntry','RawValue' | WithFallback:'',null %}
+          {% assign format = item | Attribute:'ContentFormat' %}
+          {% assign verb = item | Attribute:'ContentFormat','Object' | Attribute:'Verb' %}
 
-        {% if relatedItemGuid and relatedItemGuid != emtpy and relatedItemGuid != '' %}
+          {% if relatedItemGuid and relatedItemGuid != emtpy and relatedItemGuid != '' %}
 
-          {% contentchannelitem where:'Guid == "{{ relatedItemGuid }}"' iterator:'relatedItems' %}
-            {% assign relatedItem = relatedItems | First %}
-          {% endcontentchannelitem %}
+            {% contentchannelitem where:'Guid == "{{ relatedItemGuid }}"' iterator:'relatedItems' %}
+              {% assign relatedItem = relatedItems | First %}
+            {% endcontentchannelitem %}
 
-          {% assign title = relatedItem.Title | Replace:"'","’" %}
-          {% assign subtitle = relatedItem | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
-          {% capture permalink %}{[ getPermalink cciid:'{{ relatedItem.Id }}' ]}{% endcapture %}
-          {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:permalink %}
-          {% assign imageurl = relatedItem | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
-          {% assign target = null %}
+            {% assign title = relatedItem.Title | Replace:"'","’" %}
+            {% assign subtitle = relatedItem | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
+            {% capture permalink %}{[ getPermalink cciid:'{{ relatedItem.Id }}' ]}{% endcapture %}
+            {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:permalink %}
+            {% assign imageurl = relatedItem | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
+            {% assign target = null %}
 
-        {% else %}
+          {% else %}
 
-          {% assign title = item.Title | Replace:"'","’" %}
-          {% assign subtitle = item | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
-          {% assign imageurl = item | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
-          {% assign resourcelink = item | Attribute:'Link','RawValue' %}
-          {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:resourcelink %}
-          {% assign target = '_blank' %}
+            {% assign title = item.Title | Replace:"'","’" %}
+            {% assign subtitle = item | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
+            {% assign imageurl = item | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
+            {% assign resourcelink = item | Attribute:'Link','RawValue' %}
+            {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:resourcelink %}
+            {% assign target = '_blank' %}
 
-        {% endif %}
+          {% endif %}
 
-        {[ card title:'{{ title }}' titlesize:'h4' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' type:'{{ format }}' linkurl:'{{ linkurl }}' linktext:'{{ verb }} {{ format }}' target:'{{ target }}' ]}
+          {[ card title:'{{ title }}' titlesize:'h4' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' type:'{{ format }}' linkurl:'{{ linkurl }}' linktext:'{{ verb }} {{ format }}' target:'{{ target }}' ]}
 
-      </div>{% endfor %}
-    </div>
+        </div>{% endfor %}
+      </div>
 
-    <p class="xs-push-half-bottom"><a href="/groups/resources" class="btn xs-btn-block btn-primary shadowed"><i class="fas fa-sm fa-book push-quarter-right"></i> View More Resources</a></p>
-  {% endif %}
-{% endcontentchannelitem %}
+      {% comment %} <p class="xs-push-half-bottom"><a href="/groups/resources" class="btn xs-btn-block btn-primary shadowed"><i class="fas fa-sm fa-book push-quarter-right"></i> View More Resources</a></p> {% endcomment %}
+    {% endif %}
+  {% endcontentchannelitem %}
 {% endif %}


### PR DESCRIPTION
## DESCRIPTION

This PR removes a SQL query that previous handled returning only group leader resources that were marked for group types that the current person was in fact a leader of.

It also removes the ability for group leaders to view all resources from the content channel, for the time being.

### How do I test this PR?

## TODO

- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [X] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [X] Upload GIF(s) of relevant changes
- [X] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
