### PR TITLE
Updated editorial detail template to display 'subscribe' UI on devos

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -152,7 +152,7 @@
                 <div class="well soft-ends text-center push-bottom">
                     <h3>{{ subscribeHeading }}</h3>
                     <p>{{ subscribeText }}</p>
-                    <a href="{{ subscribeLink }}" class="btn btn-default shadowed text-gray-dark text-decoration-none" target="_blank"><i class="fas fa-fw fa-bell"></i> {{ subscribeLinkText }}</a>
+                    <a href="{{ subscribeLinkUrl }}" class="btn btn-default shadowed text-gray-dark text-decoration-none" target="_blank"><i class="fas fa-fw fa-bell"></i> {{ subscribeLinkText }}</a>
                 </div>
             {% endif %}
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -143,12 +143,18 @@
             <div class="push-bottom">
                 <div class="row row-condensed">
                     <div class="col-md-12 col-sm-12 col-xs-12">
-                        <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share="">Share <i class="fas fa-fw fa-share flush"></i></a>
-                    </div><div class="col-md-6 col-sm-6 col-xs-12 sm-push-half-bottom xs-push-half-bottom hidden">
-                        <a href="#" class="btn btn-block btn-default text-gray-dark text-decoration-none" data-like=""><i class="far fa-fw fa-heart flush"></i> 8</a>
+                        <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share=""><i class="fas fa-fw fa-share"></i> Share</a>
                     </div>
                 </div>
             </div>
+
+            {% if subscribeLinkUrl and subscribeLinkUrl != empty %}
+                <div class="well soft-ends text-center push-bottom">
+                    <h3>{{ subscribeHeading }}</h3>
+                    <p>{{ subscribeText }}</p>
+                    <a href="{{ subscribeLink }}" class="btn btn-default shadowed text-gray-dark text-decoration-none" target="_blank"><i class="fas fa-fw fa-bell"></i> {{ subscribeLinkText }}</a>
+                </div>
+            {% endif %}
 
             {%- comment -%}
                 Entry navigation


### PR DESCRIPTION
## DESCRIPTION

This PR adds the ability for users to subscribe to receive daily devos from the devo entry page.

### How do I test this PR?
- Checkout this branch
- Connection Strings to `Brian` Initial Catalog
- View the `editorial-detail` lava template [here](https://brian-new.newspring.cc/devotionals/daniel-a-14-day-devotional/we-dont-have-to-fear-the-end-of-the-world), subscribe UI should be visible.
- View the `editorial-detail` lava template [here](https://brian-new.newspring.cc/articles/marked-by-the-presence-toolkit), subscribe UI should NOT be visible.

![image](https://user-images.githubusercontent.com/2465823/95205370-4601de00-07b3-11eb-8b4e-b7523b42e214.png)


## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
