### PR TITLE
Updated content lava templates to correctly 404 when an associated content Item is not passed in correctly, and to also not write an interaction

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
@@ -1,8 +1,8 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
-{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
+{% assign itemId = Item.Id | AsInteger %}
+{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/collection-detail.lava
@@ -1,13 +1,13 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign itemId = Item.Id | AsInteger %}
-{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
+{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
+{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}
 
-{% if publishDateTime > now or expireDateTime and expireDateTime != empty and expireDateTime <= now or Item == null %}
+{% if Item == null or Item == empty or publishDateTime > now or expireDateTime and expireDateTime != empty and expireDateTime <= now %}
     {% if CurrentPersonCanEdit %}
         <p class="alert alert-danger">If you could not edit you would be redirected to <a href="/page-not-found">/page-not-found</a> as this entry is not active.</p>
     {% else %}
@@ -15,78 +15,83 @@
     {% endif %}
 {% endif %}
 
-{% comment %}
-    Write content channel item interaction
-{% endcomment %}
-{% assign currentUrl = 'Global'| Page:'Url' %}
-{% assign siteId = 'Global' | Page:'SiteId' %}
-{% assign source = 'Global'| PageParameter:'utm_source' %}
-{% assign medium = 'Global'| PageParameter:'utm_medium' %}
-{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
-{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+{% if Item and Item != empty %}
 
-{% assign pagePath = 'Global' | Page:'Path' %}
-{% assign orgName = 'Global' | Attribute:'OrganizationName' %}
-{% assign channelName = Item.ContentType | Pluralize %}
-{% assign pageTitle = Item.ContentType %}
-{% capture browserTitle %}{{ Item.Title }} | {{ channelName }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
-
-{{ browserTitle | SetPageTitle:'BrowserTitle' }}
-{{ pageTitle | SetPageTitle:'PageTitle' }}
-
-{% assign defaultTranslation = 'Global' | Attribute:'BibleTranslation','Value' %}
-{[ scripturize defaulttranslation:'{{ defaultTranslation }}' landingsite:'BibleGateway' cssclass:'scripture' openintab:'true' ]}
-
-    {% if Item.BackgroundColor != empty %}
-        <style>
-            .brand-bg {
-                background-color: {{ Item.BackgroundColor | Prepend:'#' }};
-            }
-        </style>
-    {% endif %}
+    {% comment %}
+        Write content channel item interaction
+    {% endcomment %}
+    {% assign currentUrl = 'Global'| Page:'Url' %}
+    {% assign siteId = 'Global' | Page:'SiteId' %}
+    {% assign source = 'Global'| PageParameter:'utm_source' %}
+    {% assign medium = 'Global'| PageParameter:'utm_medium' %}
+    {% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+    {% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
 
 
-    <!-- SIDE BY SIDE -->
-    {% assign id = Item.Id %}
-    {% assign cciid = Item.Id %}
-    {% assign dataset = Item.Dataset %}
-    {% assign guid = Item.Guid %}
-    {% assign title = Item.Title | Replace:"'","’" %}
-    {% assign content = Item.Summary | HtmlDecode | Replace:"'","’" %}
+    {% assign pagePath = 'Global' | Page:'Path' %}
+    {% assign orgName = 'Global' | Attribute:'OrganizationName' %}
+    {% assign channelName = Item.ContentType | Pluralize %}
+    {% assign pageTitle = Item.ContentType %}
+    {% capture browserTitle %}{{ Item.Title }} | {{ channelName }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
 
-    {% assign isDateVisible = Item.IsDateVisible %}
-    {% if isDateVisible == 'Yes' %}
-        {% if Item.StartDateTime != empty %}
-            {% capture subtitle %}{[ formatDate date:'{{ Item.StartDateTime }}' ]}{% if Item.EndDateTime != empty and Item.StartDateTime != Item.EndDateTime %} - {[ formatDate date:'{{ Item.EndDateTime }}' ]}{% endif %}{% endcapture %}
+    {{ browserTitle | SetPageTitle:'BrowserTitle' }}
+    {{ pageTitle | SetPageTitle:'PageTitle' }}
+
+    {% assign defaultTranslation = 'Global' | Attribute:'BibleTranslation','Value' %}
+    {[ scripturize defaulttranslation:'{{ defaultTranslation }}' landingsite:'BibleGateway' cssclass:'scripture' openintab:'true' ]}
+
+        {% if Item.BackgroundColor != empty %}
+            <style>
+                .brand-bg {
+                    background-color: {{ Item.BackgroundColor | Prepend:'#' }};
+                }
+            </style>
         {% endif %}
-    {% endif %}
 
-    {% capture imageurl %}{{ Item.ImageSquare }}{% endcapture %}
-    {% capture imagealignment %}Left{% endcapture %}
-    {% capture video %}{{ Item.Video }}{% endcapture %}
-    {% capture ratio %}square{% endcapture %}
-    {% capture trimcopy %}Yes{% endcapture %}
 
-    {% assign childType = Item.Children | First | Property:'Dataset' | PersistedDataset | First | Property:'ChannelName' | Split:' - ' | Index:1 %}
-    {% if childType and childType != empty %}
-        {% capture linkurl %}#entries{% endcapture %}
-        {% capture linktext %}{{ childType | Prepend:' ' | Prepend:Item.ChannelVerb }}{% endcapture %}
-    {% endif %}
+        <!-- SIDE BY SIDE -->
+        {% assign id = Item.Id %}
+        {% assign cciid = Item.Id %}
+        {% assign dataset = Item.Dataset %}
+        {% assign guid = Item.Guid %}
+        {% assign title = Item.Title | Replace:"'","’" %}
+        {% assign content = Item.Summary | HtmlDecode | Replace:"'","’" %}
 
-    {[ sideBySide id:'{{ id }}' dataset:'{{ dataset }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava | Escape }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+        {% assign isDateVisible = Item.IsDateVisible %}
+        {% if isDateVisible == 'Yes' %}
+            {% if Item.StartDateTime != empty %}
+                {% capture subtitle %}{[ formatDate date:'{{ Item.StartDateTime }}' ]}{% if Item.EndDateTime != empty and Item.StartDateTime != Item.EndDateTime %} - {[ formatDate date:'{{ Item.EndDateTime }}' ]}{% endif %}{% endcapture %}
+            {% endif %}
+        {% endif %}
 
-{[ endscripturize ]}
+        {% capture imageurl %}{{ Item.ImageSquare }}{% endcapture %}
+        {% capture imagealignment %}Left{% endcapture %}
+        {% capture video %}{{ Item.Video }}{% endcapture %}
+        {% capture ratio %}square{% endcapture %}
+        {% capture trimcopy %}Yes{% endcapture %}
 
-{% assign metaTitle = Item.MetaTitle %}
-{% assign metaDescription = Item.MetaDescription %}
-{% assign summary = Item.Summary | HtmlDecode | StripHtml | StripNewlines %}
-{% assign content = Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' %}
-{% capture article_author %}{[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
+        {% assign childType = Item.Children | First | Property:'Dataset' | PersistedDataset | First | Property:'ChannelName' | Split:' - ' | Index:1 %}
+        {% if childType and childType != empty %}
+            {% capture linkurl %}#entries{% endcapture %}
+            {% capture linktext %}{{ childType | Prepend:' ' | Prepend:Item.ChannelVerb }}{% endcapture %}
+        {% endif %}
 
-{%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
-{% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
+        {[ sideBySide id:'{{ id }}' dataset:'{{ dataset }}' cciid:'{{ cciid }}' guid:'{{ guid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava | Escape }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
 
-{%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
-{% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
+    {[ endscripturize ]}
 
-{[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.PublishDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}
+    {% assign metaTitle = Item.MetaTitle %}
+    {% assign metaDescription = Item.MetaDescription %}
+    {% assign summary = Item.Summary | HtmlDecode | StripHtml | StripNewlines %}
+    {% assign content = Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' %}
+    {% capture article_author %}{[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
+
+    {%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
+    {% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
+
+    {%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
+    {% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
+
+    {[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.PublishDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}
+
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -1,8 +1,8 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
-{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
+{% assign itemId = Item.Id | AsInteger %}
+{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -1,11 +1,19 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign itemId = Item.Id | AsInteger %}
-{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
+{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
+{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}
+
+{% if Item == null %}
+    {% if CurrentPersonCanEdit %}
+        <p class="alert alert-danger">If you could not edit you would be redirected to <a href="/page-not-found">/page-not-found</a> as this entry is not active.</p>
+    {% else %}
+        {{ '/page-not-found' | PageRedirect }}
+    {% endif %}
+{% endif %}
 
 {% if Item.ChannelId == 17 %}
     {% if expireDateTime and expireDateTime != empty and expireDateTime <= now %}
@@ -25,257 +33,261 @@
     {% endif %}
 {% endif %}
 
-{% comment %}
-    Write content channel item interaction
-{% endcomment %}
-{% assign currentUrl = 'Global'| Page:'Url' %}
-{% assign siteId = 'Global' | Page:'SiteId' %}
-{% assign source = 'Global'| PageParameter:'utm_source' %}
-{% assign medium = 'Global'| PageParameter:'utm_medium' %}
-{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
-{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+{% if Item and Item != empty and Item != null %}
 
-{% comment %}
-    Set item properties
-{% endcomment %}
-{% capture date %}{[ formatDate date:'{{ Item.PublishDateTime }}' ]}{% endcapture %}
-{% capture tags %}{[ tags dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
-{% assign tags = tags | Trim %}
-{% capture communicators %}{[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
-{% capture scripturereferences %}{% for scripture in Item.Scriptures %}{{ scripture.Book }} {{ scripture.Reference }}{% unless forloop.last %}, {% endunless %}{% endfor %}{% endcapture %}
-{% assign scripturereferences = scripturereferences | Trim %}
-{% assign itemsManuallyOrdered = Item.ItemsOrderedManually %}
+    {% comment %}
+        Write content channel item interaction
+    {% endcomment %}
+    {% assign currentUrl = 'Global'| Page:'Url' %}
+    {% assign siteId = 'Global' | Page:'SiteId' %}
+    {% assign source = 'Global'| PageParameter:'utm_source' %}
+    {% assign medium = 'Global'| PageParameter:'utm_medium' %}
+    {% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+    {% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
 
-{% comment %}
-    Set parent properties
-{% endcomment %}
-{% if Item.Parents != null %}
-    {% assign parentChannelId = Item.ParentChannelId | AsInteger %}
-    {% assign parentItem = Item.Parents | Where:'ChannelId', parentChannelId | First %}
-    {% assign parentItem = parentItem.Dataset | PersistedDataset | Where:'Id',parentItem.Id | First %}
-    {% assign itemsManuallyOrdered = parentItem.ChildItemsOrderedManually %}
-    {% assign parentImage = parentItem.ImageLandscape %}
-    {% capture parentPermalink %}{[ getPermalink cciid:'{{ parentItem.Id }}' ]}{% endcapture %}
-    {% assign totalChildren = parentItem.Children | Size %}
-{% endif %}
+    {% comment %}
+        Set item properties
+    {% endcomment %}
+    {% capture date %}{[ formatDate date:'{{ Item.PublishDateTime }}' ]}{% endcapture %}
+    {% capture tags %}{[ tags dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
+    {% assign tags = tags | Trim %}
+    {% capture communicators %}{[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
+    {% capture scripturereferences %}{% for scripture in Item.Scriptures %}{{ scripture.Book }} {{ scripture.Reference }}{% unless forloop.last %}, {% endunless %}{% endfor %}{% endcapture %}
+    {% assign scripturereferences = scripturereferences | Trim %}
+    {% assign itemsManuallyOrdered = Item.ItemsOrderedManually %}
 
-{% comment %}
-    Set page/browser titles
-{% endcomment %}
-{% assign pagePath = 'Global' | Page:'Path' %}
-{% assign orgName = 'Global' | Attribute:'OrganizationName' %}
-{% capture browserTitle %}{{ Item.Title }}{% if parentTitle and parentTitle != empty %} | {{ parentTitle }}{% endif %} | {{ Item.ContentType | Pluralize }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
-
-{{ browserTitle | SetPageTitle:'BrowserTitle' }}
-{{ Item.ContentType | SetPageTitle:'PageTitle' }}
-
-{% comment %}
-    Set page background color from parent property
-{% endcomment %}
-{% assign parentBackgroundColor = parentItem.BackgroundColor %}
-{% if parentBackgroundColor != empty %}
-    <style>
-        .brand-bg {
-            background-color: {{ parentBackgroundColor }};
-        }
-    </style>
-{% endif %}
-
-
-{% comment %}
-    Calculate prev/next entry links
-{% endcomment %}
-{% if itemsManuallyOrdered == 'true' %}
-    {% assign currentSlug = 'Global' | PageParameter:'Slug' %}
-    {% assign itemIndex = parentItem.Children | Where:'Slug', currentSlug | Select:'Index' | First | Plus:1 %}
-    {% assign prevIndex = itemIndex | Minus:2 %}
-    {% assign nextIndex = itemIndex %}
-
-    {% if itemIndex and itemIndex != empty %}
-        {% assign label = itemIndex | Prepend:'Session '%}
+    {% comment %}
+        Set parent properties
+    {% endcomment %}
+    {% if Item.Parents != null %}
+        {% assign parentChannelId = Item.ParentChannelId | AsInteger %}
+        {% assign parentItem = Item.Parents | Where:'ChannelId', parentChannelId | First %}
+        {% assign parentItem = parentItem.Dataset | PersistedDataset | Where:'Id',parentItem.Id | First %}
+        {% assign itemsManuallyOrdered = parentItem.ChildItemsOrderedManually %}
+        {% assign parentImage = parentItem.ImageLandscape %}
+        {% capture parentPermalink %}{[ getPermalink cciid:'{{ parentItem.Id }}' ]}{% endcapture %}
+        {% assign totalChildren = parentItem.Children | Size %}
     {% endif %}
-{% endif %}
 
-{% assign defaultTranslation = 'Global' | Attribute:'BibleTranslation','Value' %}
-{[ scripturize defaulttranslation:'{{ defaultTranslation }}' landingsite:'BibleGateway' cssclass:'scripture' openintab:'true' ]}
+    {% comment %}
+        Set page/browser titles
+    {% endcomment %}
+    {% assign pagePath = 'Global' | Page:'Path' %}
+    {% assign orgName = 'Global' | Attribute:'OrganizationName' %}
+    {% capture browserTitle %}{{ Item.Title }}{% if parentTitle and parentTitle != empty %} | {{ parentTitle }}{% endif %} | {{ Item.ContentType | Pluralize }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
 
-    <div class="md-text-constrained md-mx-auto panel overflow-hidden">
-        <div class="editorial-content position-relative panel-body bg-white xs-soft xs-soft-half-bottom hard-bottom">
+    {{ browserTitle | SetPageTitle:'BrowserTitle' }}
+    {{ Item.ContentType | SetPageTitle:'PageTitle' }}
 
-            {% if label and label != empty %}
-                <p><small class="label bg-gray-light sans-serif letter-spacing-condensed circular">{{ label }}</small></p>
-            {% endif %}
+    {% comment %}
+        Set page background color from parent property
+    {% endcomment %}
+    {% assign parentBackgroundColor = parentItem.BackgroundColor %}
+    {% if parentBackgroundColor != empty %}
+        <style>
+            .brand-bg {
+                background-color: {{ parentBackgroundColor }};
+            }
+        </style>
+    {% endif %}
 
-            <h1 class="h2 xs-h3 push-half-bottom xs-push-half-bottom">{{ Item.Title }}</h1>
 
-            {% if parentItem and parentItem != empty %}
-                <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentItem.Title }}{% if parentPermalink != empty %}</a>{% endif %}</small>
-            {% endif %}
+    {% comment %}
+        Calculate prev/next entry links
+    {% endcomment %}
+    {% if itemsManuallyOrdered == 'true' %}
+        {% assign currentSlug = 'Global' | PageParameter:'Slug' %}
+        {% assign itemIndex = parentItem.Children | Where:'Slug', currentSlug | Select:'Index' | First | Plus:1 %}
+        {% assign prevIndex = itemIndex | Minus:2 %}
+        {% assign nextIndex = itemIndex %}
 
-            {% if Item.Subtitle != empty %}
-                <p class="lead text-gray-light"><i>{{ Item.Subtitle }}</i></p>
-            {% endif %}
+        {% if itemIndex and itemIndex != empty %}
+            {% assign label = itemIndex | Prepend:'Session '%}
+        {% endif %}
+    {% endif %}
 
-            {% if communicators and communicators != '' %}
-                <p class="stronger">{{ communicators }}</p>
-            {% endif %}
+    {% assign defaultTranslation = 'Global' | Attribute:'BibleTranslation','Value' %}
+    {[ scripturize defaulttranslation:'{{ defaultTranslation }}' landingsite:'BibleGateway' cssclass:'scripture' openintab:'true' ]}
 
-            {% if Item.ImageLandscape and Item.ImageLandscape != empty %}
-                <div class="ratio-landscape background-cover push-bottom rounded" style="background-image:url('{{ Item.ImageLandscape }}');"></div>
-            {% endif %}
+        <div class="md-text-constrained md-mx-auto panel overflow-hidden">
+            <div class="editorial-content position-relative panel-body bg-white xs-soft xs-soft-half-bottom hard-bottom">
 
-            {%  if scripturereferences and scripturereferences != empty %}
-                <div class="text-center soft-ends">
-                    <h2 class="h3 flush">Read</h2>
-                    <p class="lead">{{ scripturereferences }}</p>
-                </div>
-            {% endif %}
+                {% if label and label != empty %}
+                    <p><small class="label bg-gray-light sans-serif letter-spacing-condensed circular">{{ label }}</small></p>
+                {% endif %}
 
-            {% if Item.Video != empty %}
-                <p id="video" class="text-center">
-                    {[ wistiaButton id:'{{ Item.Video }}' buttontext:'' buttonclasses:'' contentchannelitemid:'{{ Item.Id }}' entitytypeid:'' entityid:'' ]}
-                </p>
+                <h1 class="h2 xs-h3 push-half-bottom xs-push-half-bottom">{{ Item.Title }}</h1>
 
-            {% endif %}
+                {% if parentItem and parentItem != empty %}
+                    <small class="display-inline-block sans-serif stronger letter-spacing-condensed push-bottom">From {% if parentPermalink != empty %}<a href="{{ parentPermalink }}">{% endif %}{{ parentItem.Title }}{% if parentPermalink != empty %}</a>{% endif %}</small>
+                {% endif %}
 
-            {{ Item.Content | HtmlDecode }}
+                {% if Item.Subtitle != empty %}
+                    <p class="lead text-gray-light"><i>{{ Item.Subtitle }}</i></p>
+                {% endif %}
 
-            <div class="push-bottom">
-                <div class="row row-condensed">
-                    <div class="col-md-12 col-sm-12 col-xs-12">
-                        <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share=""><i class="fas fa-fw fa-share"></i> Share</a>
+                {% if communicators and communicators != '' %}
+                    <p class="stronger">{{ communicators }}</p>
+                {% endif %}
+
+                {% if Item.ImageLandscape and Item.ImageLandscape != empty %}
+                    <div class="ratio-landscape background-cover push-bottom rounded" style="background-image:url('{{ Item.ImageLandscape }}');"></div>
+                {% endif %}
+
+                {%  if scripturereferences and scripturereferences != empty %}
+                    <div class="text-center soft-ends">
+                        <h2 class="h3 flush">Read</h2>
+                        <p class="lead">{{ scripturereferences }}</p>
+                    </div>
+                {% endif %}
+
+                {% if Item.Video != empty %}
+                    <p id="video" class="text-center">
+                        {[ wistiaButton id:'{{ Item.Video }}' buttontext:'' buttonclasses:'' contentchannelitemid:'{{ Item.Id }}' entitytypeid:'' entityid:'' ]}
+                    </p>
+
+                {% endif %}
+
+                {{ Item.Content | HtmlDecode }}
+
+                <div class="push-bottom">
+                    <div class="row row-condensed">
+                        <div class="col-md-12 col-sm-12 col-xs-12">
+                            <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share=""><i class="fas fa-fw fa-share"></i> Share</a>
+                        </div>
                     </div>
                 </div>
+
+                {% if subscribeLinkUrl and subscribeLinkUrl != empty %}
+                    <div class="well soft-ends text-center push-bottom">
+                        <h3>{{ subscribeHeading }}</h3>
+                        <p>{{ subscribeText }}</p>
+                        <a href="{{ subscribeLinkUrl }}" class="btn btn-default shadowed text-gray-dark text-decoration-none" target="_blank"><i class="fas fa-fw fa-bell"></i> {{ subscribeLinkText }}</a>
+                    </div>
+                {% endif %}
+
+                {%- comment -%}
+                    Entry navigation
+                {%- endcomment -%}
+                {% if itemsManuallyOrdered == 'true' %}
+                    <div class="row flush-sides push-bottom xs-push-half-bottom">
+                        <div class="col-xs-4 col-sm-4 col-md-4 hard">
+                            {% if itemIndex and itemIndex != 0 %}<a href="{{ parentItem.Children | Index:prevIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom"><i class="fas fa-angle-left"></i> Prev</a>{% endif %}
+                        </div><div class="col-xs-4 col-sm-4 col-md-4 text-center hard">
+                            <p class="text-gray-light flush"><i>{{ itemIndex }} of {{ totalChildren }}</i></p>
+                        </div><div class="col-xs-4 col-sm-4 col-md-4 text-right hard">
+                            {% if itemIndex and itemIndex != totalChildren %}<a href="{{ parentItem.Children | Index:nextIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom">Next <i class="fas fa-angle-right"></i></a>{% endif %}
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% comment %}
+                    Define data for social sharing modal
+                {% endcomment %}
+                {% assign itemToken = 'cci' | Append:Item.ChannelId | Append:Item.Id %}
+                {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
+                {% assign shareimageurl = Item.ImageLandscape %}
+                {% assign shareauthor = 'newspring' %}
+                {% assign sharetitle = Item.Title %}
+                {%- capture sharesummary -%}
+                    {% if Item.Summary and Item.Summary != empty %}
+                        {{ Item.Summary | StripHtml | HtmlDecode | Truncate:150,'...' }}
+                    {% else %}
+                        {{ Item.Content | StripHtml | HtmlDecode | Truncate:150,'...' }}
+                    {% endif %}
+                {%- endcapture -%}
+                {% assign sharehashtag = '' %}
+
+                {[ modalShare ]}
+
+                {% comment %}
+                    Display date/tags if they should be visible
+                {% endcomment %}
+                {% if Item.IsDateVisible == 'Yes' %}
+                    {% if tags and tags != empty %}
+                        <div class="row push-bottom xs-push-half-bottom">
+                            <div class="col-md-6 col-sm-6 col-xs-12 xs-text-center">
+                                {{ tags }}
+                            </div><div class="col-md-6 col-sm-6 col-xs-12 text-right xs-text-center">
+                                <p class="flush"><small><b>{{ date }}</b></small></p>
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="row push-bottom xs-push-half-bottom">
+                            <div class="col-md-12 col-sm-12 col-xs-12 text-center xs-text-center">
+                                <p class="flush"><small><b>{{ date }}</b></small></p>
+                            </div>
+                        </div>
+                    {% endif %}
+                {% else %}
+                    {% if tags and tags != empty and tags != '' %}
+                        <div class="row push-bottom xs-push-half-bottom">
+                            <div class="col-xs-12 text-center">
+                                {{ tags }}
+                            </div>
+                        </div>
+                    {% endif %}
+                {% endif %}
+
             </div>
-
-            {% if subscribeLinkUrl and subscribeLinkUrl != empty %}
-                <div class="well soft-ends text-center push-bottom">
-                    <h3>{{ subscribeHeading }}</h3>
-                    <p>{{ subscribeText }}</p>
-                    <a href="{{ subscribeLinkUrl }}" class="btn btn-default shadowed text-gray-dark text-decoration-none" target="_blank"><i class="fas fa-fw fa-bell"></i> {{ subscribeLinkText }}</a>
-                </div>
-            {% endif %}
-
-            {%- comment -%}
-                Entry navigation
-            {%- endcomment -%}
-            {% if itemsManuallyOrdered == 'true' %}
-                <div class="row flush-sides push-bottom xs-push-half-bottom">
-                    <div class="col-xs-4 col-sm-4 col-md-4 hard">
-                        {% if itemIndex and itemIndex != 0 %}<a href="{{ parentItem.Children | Index:prevIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom"><i class="fas fa-angle-left"></i> Prev</a>{% endif %}
-                    </div><div class="col-xs-4 col-sm-4 col-md-4 text-center hard">
-                        <p class="text-gray-light flush"><i>{{ itemIndex }} of {{ totalChildren }}</i></p>
-                    </div><div class="col-xs-4 col-sm-4 col-md-4 text-right hard">
-                        {% if itemIndex and itemIndex != totalChildren %}<a href="{{ parentItem.Children | Index:nextIndex | Property:'Slug' }}" class="btn xs-btn-sm btn-primary xs-push-half-bottom">Next <i class="fas fa-angle-right"></i></a>{% endif %}
-                    </div>
-                </div>
-            {% endif %}
-
-            {% comment %}
-                Define data for social sharing modal
-            {% endcomment %}
-            {% assign itemToken = 'cci' | Append:Item.ChannelId | Append:Item.Id %}
-            {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
-            {% assign shareimageurl = Item.ImageLandscape %}
-            {% assign shareauthor = 'newspring' %}
-            {% assign sharetitle = Item.Title %}
-            {%- capture sharesummary -%}
-                {% if Item.Summary and Item.Summary != empty %}
-                    {{ Item.Summary | StripHtml | HtmlDecode | Truncate:150,'...' }}
-                {% else %}
-                    {{ Item.Content | StripHtml | HtmlDecode | Truncate:150,'...' }}
-                {% endif %}
-            {%- endcapture -%}
-            {% assign sharehashtag = '' %}
-
-            {[ modalShare ]}
-
-            {% comment %}
-                Display date/tags if they should be visible
-            {% endcomment %}
-            {% if Item.IsDateVisible == 'Yes' %}
-                {% if tags and tags != empty %}
-                    <div class="row push-bottom xs-push-half-bottom">
-                        <div class="col-md-6 col-sm-6 col-xs-12 xs-text-center">
-                            {{ tags }}
-                        </div><div class="col-md-6 col-sm-6 col-xs-12 text-right xs-text-center">
-                            <p class="flush"><small><b>{{ date }}</b></small></p>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="row push-bottom xs-push-half-bottom">
-                        <div class="col-md-12 col-sm-12 col-xs-12 text-center xs-text-center">
-                            <p class="flush"><small><b>{{ date }}</b></small></p>
-                        </div>
-                    </div>
-                {% endif %}
-            {% else %}
-                {% if tags and tags != empty and tags != '' %}
-                    <div class="row push-bottom xs-push-half-bottom">
-                        <div class="col-xs-12 text-center">
-                            {{ tags }}
-                        </div>
-                    </div>
-                {% endif %}
-            {% endif %}
-
         </div>
-    </div>
 
-{[ endscripturize ]}
+    {[ endscripturize ]}
 
-{% comment %}
-    Setup structured data JSON
-{% endcomment %}
-<!-- Content Structured Data -->
-{% capture tagsData %}{% for tag in Item.Tags %}{{ tag.Name }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "Article",
-  "publisher": {
-    "@type": "Organization",
-    "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://newspring.cc/GetImage.ashx?id=661329"
-    }
-  },
-  "author": {
-    "@type": "{% if communicators and communicators != empty and communicators != '' %}Person{% else %}Organization{% endif %}",
-    "name": "{% if communicators and communicators != empty and communicators != '' %}{{ communicators | Trim }}{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}"
-  },
-  {% if tagsData and tagsData != empty %}
-    "keywords": "{{ tagsData }}",
-  {% endif %}
-  "headline": "{{ Item.Title | Escape }}",
-  {% if Item.Summary and Item.Summary != empty %}
-    "description": "{{ Item.Summary | HtmlDecode | StripHtml | Escape }}",
-  {% endif %}
-  "articleBody": "{{ Item.Content | HtmlDecode | StripHtml | Escape }}",
-  {% if Item.Subtitle and Item.Subtitle != empty %}
-    "alternativeHeadline": "{{ Item.Subtitle }}",
-  {% endif %}
-
-  "datePublished": "{{ Item.PublishDateTime }}",
-  "dateModified": "{{ Item.ModifiedDateTime }}",
-    {% if Item.ExpireDateTime %}
-    "expires": "{{ Item.ExpireDateTime }}",
+    {% comment %}
+        Setup structured data JSON
+    {% endcomment %}
+    <!-- Content Structured Data -->
+    {% capture tagsData %}{% for tag in Item.Tags %}{{ tag.Name }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+    <script type="application/ld+json">
+    {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "publisher": {
+        "@type": "Organization",
+        "name": "{{ 'Global' | Attribute:'OrganizationName' }}",
+        "logo": {
+        "@type": "ImageObject",
+        "url": "https://newspring.cc/GetImage.ashx?id=661329"
+        }
+    },
+    "author": {
+        "@type": "{% if communicators and communicators != empty and communicators != '' %}Person{% else %}Organization{% endif %}",
+        "name": "{% if communicators and communicators != empty and communicators != '' %}{{ communicators | Trim }}{% else %}{{ 'Global' | Attribute:'OrganizationName' }}{% endif %}"
+    },
+    {% if tagsData and tagsData != empty %}
+        "keywords": "{{ tagsData }}",
+    {% endif %}
+    "headline": "{{ Item.Title | Escape }}",
+    {% if Item.Summary and Item.Summary != empty %}
+        "description": "{{ Item.Summary | HtmlDecode | StripHtml | Escape }}",
+    {% endif %}
+    "articleBody": "{{ Item.Content | HtmlDecode | StripHtml | Escape }}",
+    {% if Item.Subtitle and Item.Subtitle != empty %}
+        "alternativeHeadline": "{{ Item.Subtitle }}",
     {% endif %}
 
-  {% if Item.ImageLandscape and Item.ImageLandscape != empty %}
-    "image": "{{ Item.ImageLandscape }}",
-  {% endif %}
-  "mainEntityOfPage": "{{ 'Global' | Page:'Url' }}",
-  "name": "{{ Item.Title | Escape }}"
-}
-</script>
+    "datePublished": "{{ Item.PublishDateTime }}",
+    "dateModified": "{{ Item.ModifiedDateTime }}",
+        {% if Item.ExpireDateTime %}
+        "expires": "{{ Item.ExpireDateTime }}",
+        {% endif %}
 
-{% comment %}
-    Define data to be used for meta tags
-{% endcomment %}
-{% capture title %}{% if Item.MetaTitle and Item.MetaTitle != empty %}{{ Item.MetaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
+    {% if Item.ImageLandscape and Item.ImageLandscape != empty %}
+        "image": "{{ Item.ImageLandscape }}",
+    {% endif %}
+    "mainEntityOfPage": "{{ 'Global' | Page:'Url' }}",
+    "name": "{{ Item.Title | Escape }}"
+    }
+    </script>
 
-{% capture description %}{% if Item.MetaDescription and Item.MetaDescription != empty %}{{ Item.MetaDescription }}{% elseif Item.Summary and Item.Summary != empty %}{{ Item.Summary | HtmlDecode | StripHtml | StripNewlines }}{% else %}{{ Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' }}{% endif %}{% endcapture %}
+    {% comment %}
+        Define data to be used for meta tags
+    {% endcomment %}
+    {% capture title %}{% if Item.MetaTitle and Item.MetaTitle != empty %}{{ Item.MetaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
 
-{[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.PublishDateTime | Date:'yyyy-MM-dd' }}' video:'{% if Item.Video and Item.Video != empty %}https://fast.wistia.net/embed/iframe/{{ Item.Video }}?videoFoam=true{% endif %}' article_author:'{{ communicators | Trim }}' ]}
+    {% capture description %}{% if Item.MetaDescription and Item.MetaDescription != empty %}{{ Item.MetaDescription }}{% elseif Item.Summary and Item.Summary != empty %}{{ Item.Summary | HtmlDecode | StripHtml | StripNewlines }}{% else %}{{ Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' }}{% endif %}{% endcapture %}
+
+    {[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.PublishDateTime | Date:'yyyy-MM-dd' }}' video:'{% if Item.Video and Item.Video != empty %}https://fast.wistia.net/embed/iframe/{{ Item.Video }}?videoFoam=true{% endif %}' article_author:'{{ communicators | Trim }}' ]}
+
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
@@ -1,8 +1,8 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
-{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
+{% assign itemId = Item.Id | AsInteger %}
+{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
@@ -1,13 +1,14 @@
 {% comment %}
     Redirect if item is expired
 {% endcomment %}
-{% assign itemId = Item.Id | AsInteger %}
-{% assign CurrentPersonCanEdit = itemId | HasRightsTo:'Edit','Rock.Model.ContentChannelItem' %}
+{% assign pageId = 'Global' | Page:'Id' | AsInteger %}
+{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
 {% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
 {% assign publishDateTime = Item.PublishDateTime | Date:'yyyyMMddHHmm' %}
 {% assign expireDateTime = Item.ExpireDateTime | Date:'yyyyMMddHHmm' %}
 
-{% if publishDateTime > now or expireDateTime and expireDateTime != empty and expireDateTime <= now or Item == null %}
+
+{% if Item == null or publishDateTime > now or expireDateTime and expireDateTime != empty and expireDateTime <= now %}
     {% if CurrentPersonCanEdit %}
         <p class="alert alert-danger">If you could not edit you would be redirected to <a href="/page-not-found">/page-not-found</a> as this entry is not active.</p>
     {% else %}
@@ -15,135 +16,139 @@
     {% endif %}
 {% endif %}
 
-{% comment %}
-    Write content channel item interaction
-{% endcomment %}
-{% assign currentUrl = 'Global'| Page:'Url' %}
-{% assign siteId = 'Global' | Page:'SiteId' %}
-{% assign source = 'Global'| PageParameter:'utm_source' %}
-{% assign medium = 'Global'| PageParameter:'utm_medium' %}
-{% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
-{% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+{% if Item and Item != null %}
 
-{% assign parentChannelId = Item.ParentChannelId | AsInteger %}
-{% assign parent = Item.Parents | Where:'ChannelId', parentChannelId | First %}
-{% assign parentItem = parent.Dataset | PersistedDataset | Where:'Id', parent.Id | First %}
+    {% comment %}
+        Write content channel item interaction
+    {% endcomment %}
+    {% assign currentUrl = 'Global'| Page:'Url' %}
+    {% assign siteId = 'Global' | Page:'SiteId' %}
+    {% assign source = 'Global'| PageParameter:'utm_source' %}
+    {% assign medium = 'Global'| PageParameter:'utm_medium' %}
+    {% assign campaign = 'Global'| PageParameter:'utm_campaign' %}
+    {% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ Item.ChannelId }}' channelname:'{{ Item.ChannelName }}' componententitytypeid:'209' componententityid:'{{ Item.Id }}' componentname:'{{ Item.Title }}' operation:'View' summary:'Viewed "{{ Item.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
 
-{% if parentItem and parentItem != empty %}
-    {% assign parentType = parentItem.ContentType %}
-    {% assign parentTitle = parentItem.Title | Replace:"'","’" %}
-    {% assign parentSummary = parentItem.Summary | Replace:"'","’" %}
-    {% assign parentImage = parentItem.ImageLandscape %}
-    {% assign parentImageSquare = parentItem.ImageSquare %}
-    {% assign backgroundColor = parentItem.BackgroundColor %}
-    {% assign parentVideo = parentItem.Video %}
-    {% assign parentUrl = parentItem.Permalink %}
-{% endif %}
+    {% assign parentChannelId = Item.ParentChannelId | AsInteger %}
+    {% assign parent = Item.Parents | Where:'ChannelId', parentChannelId | First %}
+    {% assign parentItem = parent.Dataset | PersistedDataset | Where:'Id', parent.Id | First %}
 
-{% assign pagePath = 'Global' | Page:'Path' %}
-{% assign orgName = 'Global' | Attribute:'OrganizationName' %}
-{% assign channelName = Item.ChannelName %}
-{% capture browserTitle %}{{ Item.Title }} | {% if parentTitle and parentTitle != empty %}{{ parentTitle }} | {% endif %}{{ channelName }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
+    {% if parentItem and parentItem != empty %}
+        {% assign parentType = parentItem.ContentType %}
+        {% assign parentTitle = parentItem.Title | Replace:"'","’" %}
+        {% assign parentSummary = parentItem.Summary | Replace:"'","’" %}
+        {% assign parentImage = parentItem.ImageLandscape %}
+        {% assign parentImageSquare = parentItem.ImageSquare %}
+        {% assign backgroundColor = parentItem.BackgroundColor %}
+        {% assign parentVideo = parentItem.Video %}
+        {% assign parentUrl = parentItem.Permalink %}
+    {% endif %}
 
-{{ browserTitle | SetPageTitle:'BrowserTitle' }}
-{{ channelName | Singularize | SetPageTitle:'PageTitle' }}
+    {% assign pagePath = 'Global' | Page:'Path' %}
+    {% assign orgName = 'Global' | Attribute:'OrganizationName' %}
+    {% assign channelName = Item.ChannelName %}
+    {% capture browserTitle %}{{ Item.Title }} | {% if parentTitle and parentTitle != empty %}{{ parentTitle }} | {% endif %}{{ channelName }} | {% if pagePath contains '/fuse/' %}Fuse | {% endif %}{{ orgName }}{% endcapture %}
+
+    {{ browserTitle | SetPageTitle:'BrowserTitle' }}
+    {{ channelName | Singularize | SetPageTitle:'PageTitle' }}
 
 
 
-{% if backgroundColor and backgroundColor != empty %}
-<style>
-    .brand-bg {
-        background-color: {{ backgroundColor | Prepend:'#' }};
-    }
-</style>
-{% endif %}
+    {% if backgroundColor and backgroundColor != empty %}
+    <style>
+        .brand-bg {
+            background-color: {{ backgroundColor | Prepend:'#' }};
+        }
+    </style>
+    {% endif %}
 
-<div class="row">
-	<div class="col-md-4 col-sm-12 col-xs-12">
-        {% assign guid = Item.Guid %}
-        {% assign dataset = Item.Dataset %}
-        {% assign cciid = Item.Id %}
-        {% assign id = Item.Id %}
-        {% assign title = Item.Title | Replace:"'","’" %}
-        {% assign titlesize = 'h3' %}
-        {% assign content = Item.Summary | HtmlDecode | Replace:"'","’" %}
-        {% capture subtitle %}{[ formatDate date:'{{ Item.ActualDate }}' ]} &middot; {[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
-        {% capture imageurl %}{{ parentImage }}{% endcapture %}
-        {% capture lava %}
-            <div class="row row-condensed push-bottom xs-push-half-bottom">
-                <div class="col-md-12 col-sm-12 col-xs-12">
-                    <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share="">Share This <i class="fas fa-fw fa-share flush"></i></a>
-                </div><div class="col-md-6 col-sm-6 col-xs-12 sm-push-half-bottom xs-push-half-bottom hidden">
-                    <a href="#" class="btn btn-block btn-default text-gray-dark text-decoration-none" data-like=""><i class="far fa-fw fa-heart flush"></i> 5</a>
+    <div class="row">
+        <div class="col-md-4 col-sm-12 col-xs-12">
+            {% assign guid = Item.Guid %}
+            {% assign dataset = Item.Dataset %}
+            {% assign cciid = Item.Id %}
+            {% assign id = Item.Id %}
+            {% assign title = Item.Title | Replace:"'","’" %}
+            {% assign titlesize = 'h3' %}
+            {% assign content = Item.Summary | HtmlDecode | Replace:"'","’" %}
+            {% capture subtitle %}{[ formatDate date:'{{ Item.ActualDate }}' ]} &middot; {[ communicators dataset:'{{ Item.Dataset }}' cciid:'{{ Item.Id }}' ]}{% endcapture %}
+            {% capture imageurl %}{{ parentImage }}{% endcapture %}
+            {% capture lava %}
+                <div class="row row-condensed push-bottom xs-push-half-bottom">
+                    <div class="col-md-12 col-sm-12 col-xs-12">
+                        <a href="#" data-toggle="modal" data-target="#share-modal" class="btn btn-block btn-default text-gray-dark text-decoration-none xs-push-half-bottom" data-share="">Share This <i class="fas fa-fw fa-share flush"></i></a>
+                    </div><div class="col-md-6 col-sm-6 col-xs-12 sm-push-half-bottom xs-push-half-bottom hidden">
+                        <a href="#" class="btn btn-block btn-default text-gray-dark text-decoration-none" data-like=""><i class="far fa-fw fa-heart flush"></i> 5</a>
+                    </div>
                 </div>
-            </div>
-        {% endcapture %}
-        {% assign video = Item.Video %}
-        {% assign trimcopy = 'Yes' %}
+            {% endcapture %}
+            {% assign video = Item.Video %}
+            {% assign trimcopy = 'Yes' %}
 
-       {[ card id:'{{ id }}' dataset:'{{ dataset }}' cciid:'{{ cciid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+        {[ card id:'{{ id }}' dataset:'{{ dataset }}' cciid:'{{ cciid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
 
-        {% assign itemToken = 'cci' | Append:Item.ChannelId | Append:Item.Id %}
-        {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
+            {% assign itemToken = 'cci' | Append:Item.ChannelId | Append:Item.Id %}
+            {% assign shareurl = 'Global' | Page:'Url' | CreateShortLink:itemToken, 18, true, 7 %}
 
-        {% assign shareimageurl = Item.ImageLandscape %}
-        {% assign shareauthor = 'newspring' %}
-        {% assign sharetitle = Item.Title %}
-        {% assign summary = Item.Summary %}
-        {%- capture sharesummary -%}
-            {% if summary and summary != empty %}
-                {{ summary | HtmlDecode | StripHtml | Truncate:140,'...' }}
-            {% else %}
-                {{ Item.Content | HtmlDecode | StripHtml | Truncate:140,'...' }}
-            {% endif %}
-        {%- endcapture -%}
-        {% assign sharehashtag = '' %}
+            {% assign shareimageurl = Item.ImageLandscape %}
+            {% assign shareauthor = 'newspring' %}
+            {% assign sharetitle = Item.Title %}
+            {% assign summary = Item.Summary %}
+            {%- capture sharesummary -%}
+                {% if summary and summary != empty %}
+                    {{ summary | HtmlDecode | StripHtml | Truncate:140,'...' }}
+                {% else %}
+                    {{ Item.Content | HtmlDecode | StripHtml | Truncate:140,'...' }}
+                {% endif %}
+            {%- endcapture -%}
+            {% assign sharehashtag = '' %}
 
-        {[ modalShare ]}
+            {[ modalShare ]}
 
-	</div><div class="col-md-8 col-sm-12 col-xs-12 xs-push-half-bottom">
-        {[ wistiaEmbed id:'{{ Item.Video }}' color:'{{ backgroundColor }}' contentchannelitemid:'{{ Item.Id }}' entitytypeid:'' entityid:'' ]}
-	</div>
-</div>
+        </div><div class="col-md-8 col-sm-12 col-xs-12 xs-push-half-bottom">
+            {[ wistiaEmbed id:'{{ Item.Video }}' color:'{{ backgroundColor }}' contentchannelitemid:'{{ Item.Id }}' entitytypeid:'' entityid:'' ]}
+        </div>
+    </div>
 
-<!-- SIDE BY SIDE -->
-{% assign id = parentItem.Id %}
-{% assign cciid = parentItem.Id %}
-{% assign dataset = parentItem.Dataset %}
-{% assign title = parentTitle | Replace:"'","’" %}
-{% assign content = parentSummary | HtmlDecode | Replace:"'","’" %}
-{% assign label = parentType %}
-{% assign startDate = parentItem.StartDateTime %}
-{% assign endDate = parentItem.EndDateTime %}
+    <!-- SIDE BY SIDE -->
+    {% assign id = parentItem.Id %}
+    {% assign cciid = parentItem.Id %}
+    {% assign dataset = parentItem.Dataset %}
+    {% assign title = parentTitle | Replace:"'","’" %}
+    {% assign content = parentSummary | HtmlDecode | Replace:"'","’" %}
+    {% assign label = parentType %}
+    {% assign startDate = parentItem.StartDateTime %}
+    {% assign endDate = parentItem.EndDateTime %}
 
-{% if startDate and startDate != empty %}
-    {% capture subtitle %}{[ formatDate date:'{{ startDate }}' ]}{% if endDate and endDate != empty and startDate != endDate %} - {[ formatDate date:'{{ endDate }}' ]}{% endif %}{% endcapture %}
+    {% if startDate and startDate != empty %}
+        {% capture subtitle %}{[ formatDate date:'{{ startDate }}' ]}{% if endDate and endDate != empty and startDate != endDate %} - {[ formatDate date:'{{ endDate }}' ]}{% endif %}{% endcapture %}
+    {% endif %}
+    {% assign imageurl = parentImageSquare %}
+    {% assign imagealignment = 'Left' %}
+    {% assign video = parentVideo %}
+    {% assign ratio = 'square' %}
+    {% assign linkurl = parentUrl %}
+    {% assign linktext = 'Watch Series' %}
+
+    {[ sideBySide dataset:'{{ dataset }}' id:'{{ id }}' cciid:'{{ cciid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+
+
+
+
+    <!-- Set Meta Tags -->
+    {% assign metaTitle = Item.MetaTitle %}
+    {% assign metaDescription = Item.MetaDescription %}
+    {% assign summary = Item.Summary | HtmlDecode | StripHtml | StripNewlines %}
+    {% assign content = Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' %}
+    {% assign video = Item.Video %}
+    {% capture article_author %}{[ communicators dataset:'{{ dataset }}' cciid:'{{ id }}' ]}{% endcapture %}
+
+    {%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
+    {% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
+
+    {%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
+    {% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
+
+
+    {[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.StartDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}
+
 {% endif %}
-{% assign imageurl = parentImageSquare %}
-{% assign imagealignment = 'Left' %}
-{% assign video = parentVideo %}
-{% assign ratio = 'square' %}
-{% assign linkurl = parentUrl %}
-{% assign linktext = 'Watch Series' %}
-
-{[ sideBySide dataset:'{{ dataset }}' id:'{{ id }}' cciid:'{{ cciid }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
-
-
-
-
-<!-- Set Meta Tags -->
-{% assign metaTitle = Item.MetaTitle %}
-{% assign metaDescription = Item.MetaDescription %}
-{% assign summary = Item.Summary | HtmlDecode | StripHtml | StripNewlines %}
-{% assign content = Item.Content | HtmlDecode | StripHtml | StripNewlines | Truncate:240,'...' %}
-{% assign video = Item.Video %}
-{% capture article_author %}{[ communicators dataset:'{{ dataset }}' cciid:'{{ id }}' ]}{% endcapture %}
-
-{%- comment -%}If meta title is present, use it, otherwise use this item's title{%- endcomment -%}
-{% capture title %}{% if metaTitle and metaTitle != empty %}{{ metaTitle }}{% else %}{{ Item.Title }}{% endif %}{% endcapture %}
-
-{%- comment -%}If meta description is present, use it, otherwise if this item has a summary, use it, otherwise, use this item's content{%- endcomment -%}
-{% capture description %}{% if metaDescription and metaDescription != empty %}{{ metaDescription }}{% elseif summary and summary != empty %}{{ summary }}{% else %}{{ content }}{% endif %}{% endcapture %}
-
-
-{[ metaTags url:'{{ "Global" | Page:"Url" }}' title:'{{ title | Replace:"'","’" | Replace:"New Spring","NewSpring" }}' description:'{{ description | Replace:"'","’" }}' image:'{{ Item.ImageLandscape }}' article_published_time:'{{ Item.StartDateTime | Date:'yyyy-MM-dd' }}' video:'{% if video and video != "" %}https://fast.wistia.net/embed/iframe/{{ video }}?videoFoam=true{% endif %}' article_author:'{{ article_author | Trim }}' ]}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
Pages on newspring.cc that surfaced content have not been appropriately 404ing since the last update we made for writing interactions. We've added conditionals to each of the three lava templates to check for a valid `Item` object. If one does not exist, the page will redirect to `page-not-found` and an interaction will _not_ be written.

### How do I test this PR?
[This interaction component](https://brian-rock.newspring.cc/page/1275?ComponentId=732809) should have all of the invalid interactions in it - loading any of the associated urls from "Interaction Data" in the browser should now redirect to `page-not-found`, and a subsequent interaction should not be written.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
