### PR TITLE
Added changes to giving history lava template to give access to business transactions

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
@@ -119,10 +119,10 @@
         <h3 class="flush">Total <span class="pull-right">{{ sumTotal | FormatAsCurrency }}</span></h3>
         <p class="italic text-gray-light">{{ startDate | Date:'MMM d, yyyy' }} - {{ endDate | Date:'MMM d, yyyy' }}</p>
 
-        {% if businessId and businessId == empty %}
+        {% if businessId == null %}
             <p class="push-half-bottom">
-                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">{{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }} Contributions</a>
-                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">{{ 'Now' | Date:'yyyy' }} Contributions</a>
+                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }}" class="btn btn-primary shadowed xs-btn-block push-half-bottom">{{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }} Contributions</a>
+                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | Date:'yyyy' }}" class="btn btn-primary shadowed xs-btn-block push-half-bottom">{{ 'Now' | Date:'yyyy' }} Contributions</a>
             </p>
         {% endif %}
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
@@ -1,4 +1,42 @@
-<div id="history" class="push-bottom xs-push-half-bottom xs-push-half-top"> 
+{% assign businessIdParam = 'Global' | PageParameter:'BusinessId' %}
+{% assign pageId = 'Global' | Page:'Id' %}
+{% assign CurrentPersonCanEdit = pageId | HasRightsTo:'Edit','Rock.Model.Page' %}
+
+{% sql return:'businessIds' %}
+    SELECT gm2.PersonId
+    FROM GroupMember gm2
+    WHERE gm2.GroupId = (
+        SELECT g.Id
+        FROM GroupMember gm
+        JOIN [Group] g
+        ON gm.GroupId = g.Id
+        JOIN GroupType gt
+        ON g.GroupTypeId = gt.Id
+        WHERE gm.PersonId = {{ CurrentPerson.Id }}
+        AND gt.Id = 11
+        AND gm.GroupRoleId = 25
+    )
+    AND gm2.PersonId != {{ CurrentPerson.Id }}
+{% endsql %}
+
+{% assign businessesCount = businessIds | Size %}
+{% if businessIdParam and businessIdParam != empty %}
+    {% assign businessId = businessIds | Where:'PersonId',businessIdParam | First | Property:'PersonId' %}
+{% endif %}
+
+{%- comment -%}
+    Redirect to 404 if current person isn't connected to the
+    business that matches the ID in query string
+{%- endcomment -%}
+{% if businessId and businessId == empty %}
+    {% if CurrentPersonCanEdit %}
+        <p class="alert alert-danger">If you did not have edit rights to this page, you would be redirected to <a href="/page-not-found">/page-not-found</a>.</p>
+    {% else %}
+        {{ '/page-not-found' | PageRedirect }}
+    {% endif %}
+{% endif %}
+
+<div id="history" class="push-bottom xs-push-half-bottom xs-push-half-top">
     <h2>Giving History</h2>
 
     {%- comment -%}Setting up date range variables{%- endcomment -%}
@@ -10,94 +48,105 @@
     {% for item in queryParms %}
         {% assign kvItem = item | PropertyToKeyValue %}
         {% if kvItem.Key == 'startDate' %}
-            {% assign startDate = kvItem.Value %}                
+            {% assign startDate = kvItem.Value %}
         {% endif %}
         {% if kvItem.Key == 'endDate' %}
-            {% assign endDate = kvItem.Value %}                
+            {% assign endDate = kvItem.Value %}
         {% endif %}
     {% endfor %}
-    
+
     <div class="row"><div class="col-xs-12 col-md-6">
 
         {[ accordion ]}
         [[ item title:'<i class="fas fa-filter"></i> &nbsp;Filters' ]]
-        <h3 class="h4 push-half-bottom">Date Range</h3>
-        {% assign now = 'Now' %}
-        {% assign currentMonth = now | Date:'M' %}
-        <p>
-            <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/{{ now | Date:'yyyy' }}" data-end-date="{{ now | Date:'M/d/yyyy' }}" style="margin-bottom: 3px;">YTD</a>
-            <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="{{ now | DateAdd:-1,'M' | Date:'M' }}/1/{% if currentMonth == 1 %}{{ now | DateAdd:-1,'y' | Date:'yyyy' }}{% else %}{{ now | Date:'yyyy' }}{% endif %}" data-end-date="{{ now | DateAdd:-1,'M' | Date:'M' }}/{{ now | DateAdd:-1,'M' | DaysInMonth }}/{% if currentMonth == 1 %}{{ now | DateAdd:-1,'y' | Date:'yyyy' }}{% else %}{{ now | Date:'yyyy' }}{% endif %}" style="margin-bottom: 3px;">Last Month</a>
-            <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/{{ now | DateAdd:-1,'y' | Date:'yyyy' }}" data-end-date="12/31/{{ now | DateAdd:-1,'y' | Date:'yyyy' }}" style="margin-bottom: 3px;">Last Year</a>
-            <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/2000" data-end-date="{{ now | Date:'M/d/yyyy' }}" style="margin-bottom: 3px;">All Transactions</a>
-        </p>
-        
-    
-        <h3 class="h4 push-half-bottom">Custom Dates</h3>
-        <div class="form-group date-picker display-inline-block">
-            <div class="control-wrapper">
-                <div class="input-group input-width-md js-date-picker date">
-                    <input name="ctl00$main$ctl23$ctl01$ctl06$dpExample" type="text" id="StartDate" class="form-control datepicker" value=""><span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
-                </div><span id="StartDate_dav" class="validation-error help-inline" style="display:none;"></span>
+
+            {% if businessIds and businessIds != empty %}
+            <p>
+                <a href="{{ 'Global' | Page:'Path' }}" class="btn {% if businessId and businessId != empty %}btn-primary{% else %}btn-secondary{% endif %} btn-sm">Personal Contributions</a>
+                {% for businessRow in businessIds %}
+                    {% assign business = businessRow.PersonId | PersonById %}
+                    <a href="{{ currentUrl }}?BusinessId={{ business.Id }}" class="btn {% if businessId == businessRow.PersonId %}btn-secondary{% else %}btn-primary{% endif %} btn-sm">{{ business.LastName }}</a>
+                {% endfor %}
+            </p>
+            {% endif %}
+
+            <h3 class="h4 push-half-bottom">Date Range</h3>
+            {% assign now = 'Now' %}
+            {% assign currentMonth = now | Date:'M' %}
+            <p>
+                <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/{{ now | Date:'yyyy' }}" data-end-date="{{ now | Date:'M/d/yyyy' }}" style="margin-bottom: 3px;">YTD</a>
+                <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="{{ now | DateAdd:-1,'M' | Date:'M' }}/1/{% if currentMonth == 1 %}{{ now | DateAdd:-1,'y' | Date:'yyyy' }}{% else %}{{ now | Date:'yyyy' }}{% endif %}" data-end-date="{{ now | DateAdd:-1,'M' | Date:'M' }}/{{ now | DateAdd:-1,'M' | DaysInMonth }}/{% if currentMonth == 1 %}{{ now | DateAdd:-1,'y' | Date:'yyyy' }}{% else %}{{ now | Date:'yyyy' }}{% endif %}" style="margin-bottom: 3px;">Last Month</a>
+                <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/{{ now | DateAdd:-1,'y' | Date:'yyyy' }}" data-end-date="12/31/{{ now | DateAdd:-1,'y' | Date:'yyyy' }}" style="margin-bottom: 3px;">Last Year</a>
+                <a href="#" class="btn btn-primary btn-sm quick-filter" data-start-date="1/1/2000" data-end-date="{{ now | Date:'M/d/yyyy' }}" style="margin-bottom: 3px;">All Transactions</a>
+            </p>
+
+
+            <h3 class="h4 push-half-bottom">Custom Dates</h3>
+            <div class="form-group date-picker display-inline-block">
+                <div class="control-wrapper">
+                    <div class="input-group input-width-md js-date-picker date">
+                        <input name="ctl00$main$ctl23$ctl01$ctl06$dpExample" type="text" id="StartDate" class="form-control datepicker" value=""><span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+                    </div><span id="StartDate_dav" class="validation-error help-inline" style="display:none;"></span>
+                </div>
             </div>
-        </div>
-    
-        <div class="form-group date-picker display-inline-block">
-            <div class="control-wrapper">
-                <div class="input-group input-width-md js-date-picker date">
-                    <input name="ctl00$main$ctl23$ctl01$ctl06$dpExample" type="text" id="EndDate" class="form-control datepicker" value=""><span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
-                </div><span id="EndDate_dav" class="validation-error help-inline" style="display:none;"></span>
+
+            <div class="form-group date-picker display-inline-block">
+                <div class="control-wrapper">
+                    <div class="input-group input-width-md js-date-picker date">
+                        <input name="ctl00$main$ctl23$ctl01$ctl06$dpExample" type="text" id="EndDate" class="form-control datepicker" value=""><span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+                    </div><span id="EndDate_dav" class="validation-error help-inline" style="display:none;"></span>
+                </div>
             </div>
-        </div>
-        <p>
-            <a href="#" class="btn btn-primary btn-sm" data-filter>Filter Transactions</a>
-        </p>
+            <p>
+                <a href="#" class="btn btn-primary btn-sm" data-filter>Filter Transactions</a>
+            </p>
+
         [[ enditem ]]
         {[ endaccordion ]}
-    
+
     </div><div class="col-xs-12 col-md-6">
-    
+
         {% comment %}
             Calculate Sum of Transactions
         {% endcomment %}
-        
+
         {% assign sumTotal = 0 %}
         {% for row in rows %}
-    
+
             {% assign sumTotal = sumTotal | Plus:row.Amount %}
         {% endfor %}
-        
+
         <h3 class="flush">Total <span class="pull-right">{{ sumTotal | FormatAsCurrency }}</span></h3>
         <p class="italic text-gray-light">{{ startDate | Date:'MMM d, yyyy' }} - {{ endDate | Date:'MMM d, yyyy' }}</p>
-    
 
-        <p class="md-text-right push-half-bottom">
-            <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">View {{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }} Contributions</a> 
-            <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">View {{ 'Now' | Date:'yyyy' }} Contributions</a>
-        </p>
-
-        <p class="md-text-right hidden"><a href="https://newspring.cc/page/651?StatementYear=2019" class="btn btn-primary xs-btn-block">Print 2019 Contributions</a></p>
+        {% if businessId and businessId == empty %}
+            <p class="push-half-bottom">
+                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">{{ 'Now' | DateAdd:-1,'y' | Date:'yyyy' }} Contributions</a>
+                <a href="https://newspring.cc/page/651?StatementYear={{ 'Now' | Date:'yyyy' }}" class="btn btn-primary xs-btn-block push-half-bottom">{{ 'Now' | Date:'yyyy' }} Contributions</a>
+            </p>
+        {% endif %}
 
     </div></div>
-    
+
     {% for row in rows %}
         {% assign giver = row.PersonId | PersonById %}
         <div class="bg-white soft push-half-bottom rounded shadowed">
-        
+
             <div class="row">
                 <div class="col-xs-12 col-sm-12 col-md-6">
                     <h3 class="xs-h4 push-half-bottom">{{ row.PublicName1 }}</h3>
                 </div><div class="col-xs-12 col-sm-12 col-md-6">
-                    <h3 class="xs-h5 push-half-bottom md-text-right sm-text-left xs-text-left">{{ row.Amount | FormatAsCurrency }}</h3>
+                    <h3 class="xs-h5 push-half-bottom text-right">{{ row.Amount | FormatAsCurrency }}</h3>
                 </div>
             </div>
-            
+
             <p class="sans-serif stronger letter-spacing-condensed text-uppercase text-gray-light push-half-bottom">{{ row.TransactionDateTime | Date:'MMM d, yyyy' }}</p>
             <p class="push-half-bottom"><span class="circular background-cover" style="position:relative; top: 8px; display: inline-block; width: 30px; height: 30px; background-image:url('{{ giver.PhotoUrl }}');"></span> &nbsp;<span class="stronger">{{ row.NickName }} {{ row.LastName }}</span></p>
 
-            <p class="flush text-right"><a href="/give/transaction/{{ row.Id }}" class="btn btn-sm btn-primary" target="_blank">View Transaction</a></p>
-            
+            <p class="flush text-right"><a href="/give/transaction/{{ row.Id }}" class="btn btn-sm btn-primary">View Transaction</a></p>
+
         </div>
-        
+
     {% endfor %}
 </div>
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR introduces changes to our giving history lava template that enables users to see transactions related to their businesses, which are separate from personal transactions.

### How do I test this PR?
- Clone this branch
- Point connectionstrings to `brian`
- Impersonate `/Person/19308` (or any other person with a business attached to them)
- View giving history at `/give/history`
- In the "Filters" accordion, buttons for personal/business transactions should be visible and allow you to change which transactions you're viewing.

![image](https://user-images.githubusercontent.com/2465823/96599189-a74ea480-12bd-11eb-809a-7c7a46e43a35.png)


## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
