### PR TITLE
Added lava templates for fundraising group missions pages

### DIFF
--- a/RockWeb/Themes/NewSpring/Styles/_breakpoints.less
+++ b/RockWeb/Themes/NewSpring/Styles/_breakpoints.less
@@ -261,6 +261,8 @@
 		padding-bottom: @base-spacing-unit/3*2;
 	}
 
+	.progress { margin-bottom: @base-spacing-unit/2; }
+
 	// Buttons
 
 	.btn-primary:hover { background-color: @brand-primary; }

--- a/RockWeb/Themes/NewSpring/Styles/theme.less
+++ b/RockWeb/Themes/NewSpring/Styles/theme.less
@@ -232,4 +232,6 @@ ul, ol {
 	font-family: "colfax-web",Helvetica,Arial,sans-serif;
 }
 
+.progress { margin-bottom: @base-spacing-unit; }
+
 @import '_breakpoints';

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-leader-toolbox.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-leader-toolbox.lava
@@ -1,0 +1,18 @@
+{% assign group = 'Global' | PageParameter:'GroupId' | GroupById %}
+{% assign groupId = group.Id | AsString %}
+{% assign startDate = group | Attribute:'OpportunityDateRange','RawValue' | Split:',' | First %}
+{% assign endDate = group | Attribute:'OpportunityDateRange','RawValue' | Split:',' | Last %}
+
+<section class="bg-white soft xs-soft-half hard-bottom clearfix push-bottom xs-push-half-bottom rounded shadowed">
+  <h2 class="push-half-bottom">{{ group.Name }}</h2>
+  <div class="row">
+    <div class="col-md-9 col-xs-12">
+      <p class="lead flush">{{ group | Attribute:'OpportunityLocation' }}</p>
+      <p>{[ formatDate date:'{{ startDate }}' ]} - {[ formatDate date:'{{ endDate }}' ]}</p>
+    </div><div class="col-md-3 col-xs-12">
+      <p>
+        <a href="/missions/{{ groupId }}" class="btn btn-block btn-primary">Trip Page</a>
+      </p>
+    </div>
+  </div>
+</section>

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-opportunity-participant.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-opportunity-participant.lava
@@ -1,0 +1,112 @@
+{% assign currentUrl = 'Global' | Page:'Url' %}
+{% assign group = 'Global' | PageParameter:'GroupId' | GroupById %}
+{% assign startDate = group | Attribute:'OpportunityStartDate' %}
+{% assign endDate = group | Attribute:'OpportunityEndDate' %}
+{% assign groupMemberId = 'Global' | PageParameter:'GroupMemberId' %}
+{% assign groupMember = group.Members | Where:'Id',groupMemberId | First %}
+{% assign groupMemberPerson = groupMember.Person %}
+
+{% capture browserTitle %}{{ groupMember.Person.FullName | Possessive }} {{ group | Attribute:'OpportunityType' }} | {{ group | Attribute:'OpportunityTitle' }} | Missions | NewSpring.cc{% endcapture %}
+{{ browserTitle | SetPageTitle:'BrowserTitle' }}
+
+{% sql return:'fundraising' %}
+    SELECT
+        (
+            SELECT
+                CASE
+                    WHEN SUM(ftd.Amount) IS NULL THEN 0.00
+                    ELSE CAST(SUM(ftd.Amount) AS INT)
+                END
+            FROM FinancialTransaction ft
+            JOIN FinancialTransactionDetail ftd
+            ON ftd.TransactionId = ft.Id
+            WHERE ftd.EntityTypeId = 90
+            AND ftd.EntityId = gm.Id
+        ) 'AmountRaised',
+        CASE
+            WHEN av2.[Value] IS NOT NULL AND av2.[Value] != '' THEN CAST(av2.[Value] AS INT)
+            ELSE CAST(av.[Value] AS INT)
+        END 'FundraisingGoal'
+    FROM GroupMember gm
+    JOIN [Group] g
+    ON gm.GroupId = g.Id
+    LEFT JOIN AttributeValue av2
+    ON av2.EntityId = gm.Id
+    AND av2.AttributeId = 46538
+    LEFT JOIN AttributeValue av
+    ON av.EntityId = g.Id
+    AND av.AttributeId = 46527
+    WHERE gm.Id = {{ groupMemberId }}
+    AND gm.GroupMemberStatus = 1
+    AND gm.IsArchived = 0
+{% endsql %}
+
+{% assign fundraisingGoal = fundraising | First | Property:'FundraisingGoal' %}
+{% assign amountRaised = fundraising | First | Property:'AmountRaised' %}
+{% assign percentRaised = amountRaised | DividedBy:fundraisingGoal,2 | Times:100 | AtMost:100  %}
+
+<section class="bg-white soft hard-bottom clearfix push-bottom xs-push-half-bottom rounded shadowed">
+    <div class="row">
+        <div class="col-md-2 col-sm-2 col-xs-3">
+            <div class="ratio ratio-square background-cover circular push-bottom xs-push-half-bottom" style="background-image: url('{{ groupMemberPerson.PhotoUrl }}'); max-width: 150px;"></div>
+        </div><div class="col-md-7 col-sm-10 col-xs-9">
+            <h2 class="h1 flush">{{ groupMemberPerson.FullName | Possessive }} Trip</h2>
+            <h2 class="h4 text-gray-light push-half-bottom">{{ group | Attribute:'OpportunityLocation' }}</h2>
+            <p>{[ formatDate date:'{{ startDate }}' ]} - {[ formatDate date:'{{ endDate }}' ]}</p>
+        </div><div class="col-md-3 col-sm-12 col-xs-12">
+            <p>
+                <a href="/missions/{{ group.Id }}" class="btn btn-primary btn-block">{{ group | Attribute:'OpportunityType' }} Page</a>
+                <a href="#" class="btn btn-default btn-block js-copy"><i class="fal fa-copy push-quarter-right"></i> Copy Profile Link</a>
+            </p>
+
+            <input type="text" class="form-control js-copy-source hidden" value="{{ currentUrl }}" title="Click to Copy to Clipboard">
+
+            <script>
+            function copyPhoneNumbersForSMS() {
+                // Copies input value to clipboard on button click
+                var copyLink = document.querySelector('.js-copy');
+
+                if(copyLink) {
+                copyLink.addEventListener('click',function(e){
+                    e.preventDefault();
+                    copyLink = e.target;
+                    var copyTarget = $('.js-copy-source')[0];
+                    var copyLinkInnerHTML = copyLink.innerHTML;
+                    copyTarget.setSelectionRange(0, copyTarget.value.length);
+                    navigator.clipboard.writeText(copyTarget.value);
+                    copyLink.innerHTML = '<i class="fal fa-check push-quarter-right"></i> Copied!';
+                    copyLink.classList.toggle('btn-primary');
+                    copyLink.classList.toggle('btn-gray-dark');
+                    setTimeout(function(){
+                    copyLink.innerHTML = copyLinkInnerHTML;
+                    copyLink.classList.toggle('btn-primary');
+                    copyLink.classList.toggle('btn-gray-dark');
+                    }, 1500);
+                });
+                }
+            }
+
+            $(document).ready(function(){
+                copyPhoneNumbersForSMS();
+            });
+
+            // Handles re-binding event handlers after a postback (editing group, add/edit members, etc)
+            var prm = Sys.WebForms.PageRequestManager.getInstance();
+            if(prm){
+                prm.add_endRequest(function() {
+                copyPhoneNumbersForSMS();
+                });
+            }
+            </script>
+        </div>
+    </div>
+
+    <div class="well push-bottom">
+        <h3 class="h5 push-half-bottom">Fundraising Progress</h3>
+        <p class="push-half-bottom">{{ amountRaised | FormatAsCurrency }} <span class="pull-right">{{ fundraisingGoal | FormatAsCurrency }}</span></p>
+
+        {[ progressBar percent:'{{ percentRaised }}' colorstatus:'true' striped:'true' ]}
+
+        <p class="flush text-right"><a href="/page/1025?GroupId={{ group.Id }}&GroupMemberId={{ groupMemberId }}" class="btn btn-sm btn-primary">Contribute to {{ groupMember.Person.NickName | Possessive }} {{ group | Attribute:'OpportunityType' }}</a></p>
+    </div>
+</section>

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-opportunity-view.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-opportunity-view.lava
@@ -1,0 +1,99 @@
+{% assign currentUrl = 'Global' | Page:'Url' %}
+{% assign group = 'Global' | PageParameter:'GroupId' | GroupById %}
+{% assign groupId = group.Id | AsString %}
+{% assign startDate = group | Attribute:'OpportunityDateRange','RawValue' | Split:',' | First %}
+{% assign endDate = group | Attribute:'OpportunityDateRange','RawValue' | Split:',' | Last %}
+{% assign groupMember = CurrentPerson | Group: groupId,'All' | First %}
+{% assign now = 'Now' | Date:'yyyyMMddHHmm' %}
+{% assign donationsEndDate = group | Attribute:'AllowDonationsUntil' | Date:'yyyyMMddHHmm' %}
+
+{% capture id %}{% endcapture %}
+{% capture title %}{{ group.Name | Replace:"'","’" }}{% endcapture %}
+{% capture content %}<p class="lead">{{ group | Attribute:'OpportunityLocation' }}<br>{[ formatDate date:'{{ startDate }}' ]} - {[ formatDate date:'{{ endDate }}' ]}</p>{% endcapture %}
+{% capture textalignment %}{% endcapture %}
+{% capture label %}{% endcapture %}
+{% capture subtitle %}{% endcapture %}
+{% capture imageurl %}{{ group | Attribute:'OpportunityImage','Url' }}{% endcapture %}
+{% capture imageoverlayurl %}{% endcapture %}
+{% capture imagealignment %}{% endcapture %}
+{% capture imageopacity %}.75{% endcapture %}
+{% capture imageflip %}{% endcapture %}
+{% capture imageblur %}{% endcapture %}
+{% capture grayscale %}{% endcapture %}
+{% capture backgroundvideourl %}{% endcapture %}
+{% capture lava %}{% endcapture %}
+{% capture video %}{{ group | Attribute:'OpportunityVideo' }}{% endcapture %}
+{% capture ratio %}{% endcapture %}
+{% capture trimcopy %}{% endcapture %}
+{% capture linkcolor %}{% endcapture %}
+{% capture backgroundcolor %}{% endcapture %}
+{% capture linkurl %}{% endcapture %}
+{% capture linktext %}{% endcapture %}
+{% capture hideforegroundelements %}{% endcapture %}
+
+{[ hero id:'{{ id }}' title:'{{ title }}' content:'{{ content }}' textalignment:'{{ textalignment }}' label:'{{ label }}' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' imageoverlayurl:'{{ imageoverlayurl }}' imagealignment:'{{ imagealignment }}' imageopacity:'{{ imageopacity }}' imageflip:'{{ imageflip }}' imageblur:'{{ imageblur }}' grayscale:'{{ grayscale }}' backgroundvideourl:'{{ backgroundvideourl }}' lava:'{{ lava }}' video:'{{ video }}' ratio:'{{ ratio }}' trimcopy:'{{ trimcopy }}' linkcolor:'{{ linkcolor }}' backgroundcolor:'{{ backgroundcolor }}' linktext:'{{ linktext }}' linkurl:'{{ linkurl }}' hideforegroundelements:'{{ hideforegroundelements }}' linkedpageid:'{{ linkedpageid }}' linkedpageroute:'{{ linkedpageroute }}' ]}
+
+
+{% if groupMember and groupMember != empty %}
+
+  {% sql return:'amounts' %}
+    SELECT SUM(ftd.Amount) 'AmountRaised'
+    FROM FinancialTransaction ft
+    JOIN FinancialTransactionDetail ftd
+    ON ftd.TransactionId = ft.Id
+    WHERE ftd.EntityTypeId = 90
+    AND ftd.EntityId = {{ groupMember.Id }}
+  {% endsql %}
+
+  {% assign groupFundraisingGoal = group | Attribute:'IndividualFundraisingGoal','RawValue' %}
+  {% assign individualFundraisingGoal = groupMember | Attribute:'IndividualFundraisingGoal','RawValue' %}
+  {% assign fundraisingGoal = individualFundraisingGoal | WithFallback:'',groupFundraisingGoal | AsInteger %}
+  {% assign amountRaised = amounts | First | Property:'AmountRaised' | WithFallback:'','0' | AsInteger %}
+  {% assign percentageRaised = amountRaised | DividedBy:fundraisingGoal,2 | Times:100 %}
+  <div class="bg-white soft hard-bottom push-bottom xs-push-half-bottom rounded shadowed">
+    <div class="row">
+      <div class="col-md-9 col-sm-8 col-xs-12">
+        <h2 class="h3 push-half-bottom">Your Fundraising Progress</h2>
+        <div class="row floating floating-left floating-bottom push-half-bottom">
+          <div class="col-md-3 col-xs-3 floating-item">
+            <img src="{{ CurrentPerson.PhotoUrl }}" alt="" class="circular" style="max-width: 50px">
+          </div><div class="col-md-9 col-xs-9 floating-item text-right">
+            <p class="lead flush">${{ amountRaised | Format:'###,###,###' | Replace:'.00','' | WithFallback:'','0' }}/<b class="letter-spacing-condensed">{{ fundraisingGoal | Format:'$###,###.##' }}</b></p>
+          </div>
+        </div>
+
+        {[ progressBar percent:'{{ percentageRaised }}' striped:'true' animated:'' ]}
+
+      </div><div class="col-md-3 col-sm-4 col-xs-12">
+        <p class="xs-push-top">
+          <a href="{{ currentUrl | Append:'/participant/' | Append:groupMember.Id }}" class="btn btn-primary btn-block">Participant Page</a>
+          {% if percentageRaised and percentageRaised < 100 %}
+            <a href="{{ currentUrl | Append:'/donate?GroupMemberId=' | Append:groupMember.Id }}" class="btn btn-primary btn-block">Make Payment</a>
+          {% endif %}
+        </p>
+
+      </div>
+    </div>
+  </div>
+{% endif %}
+
+<div class="bg-white soft  hard-bottom push-bottom xs-push-half-bottom rounded shadowed">
+  <div class="row">
+    <div class="col-md-3 col-xs-12">
+      {% assign applyUrl = '/workflows/206?Trip=' | Append:group.Name | Append:'&TripType=' | Replace:"'","’" %}
+      <p>
+        <a href="{{ applyUrl }}" class="btn btn-primary btn-block">Apply Now</a>
+
+        {% if now < donationsEndDate %}
+          <a href="{{ currentUrl | Append:'/donate' }}" class="btn btn-default btn-block">Donate to a Participant</a>
+        {% endif %}
+
+        {% if groupMember.GroupRole.Id == 341 %}
+          <a href="{{ currentUrl | Append:'/leader' }}" class="btn btn-default btn-block">Leader Toolbox</a>
+        {% endif %}
+      </p>
+    </div><div class="col-md-9 col-xs-12">
+      {{ group | Attribute:'OpportunityDetails' }}
+    </div>
+  </div>
+</div>

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-progress.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/fundraising-progress.lava
@@ -1,0 +1,101 @@
+{% assign group = 'Global' | PageParameter:'GroupId' | GroupById %}
+{% assign groupId = group.Id | AsString %}
+
+{% if groupId and groupId != empty %}
+    <section class="bg-white soft xs-soft-half hard-bottom clearfix push-bottom xs-push-half-bottom rounded shadowed">
+    <h2>Fundraising Progress</h2>
+
+    {% sql return:'members' %}
+        SELECT
+            gm.Id,
+            gm.PersonId,
+            gtr.Name,
+            p.LastName,
+            p.NickName,
+            (
+                SELECT
+                    CASE
+                        WHEN SUM(ftd.Amount) IS NULL THEN 0.00
+                        ELSE SUM(ftd.Amount)
+                    END
+                FROM FinancialTransaction ft
+                JOIN FinancialTransactionDetail ftd
+                ON ftd.TransactionId = ft.Id
+                WHERE ftd.EntityTypeId = 90
+                AND ftd.EntityId = gm.Id
+            ) 'AmountRaised',
+            CASE
+                WHEN av2.[Value] IS NOT NULL AND av2.[Value] != '' THEN av2.[Value]
+                ELSE av.[Value]
+            END 'FundraisingGoal'
+        FROM GroupMember gm
+        JOIN [Group] g
+        ON gm.GroupId = g.Id
+        JOIN Person p
+        ON gm.PersonId = p.Id
+        JOIN GroupTypeRole gtr
+        ON gm.GroupRoleId = gtr.Id
+        LEFT JOIN AttributeValue av2
+        ON av2.EntityId = gm.Id
+        AND av2.AttributeId = 46538
+        LEFT JOIN AttributeValue av
+        ON av.EntityId = g.Id
+        AND av.AttributeId = 46527
+        WHERE gm.GroupId = {{ groupId }}
+        AND gm.GroupMemberStatus = 1
+        AND gm.IsArchived = 0
+        ORDER BY gtr.[Order], p.LastName, p.NickName
+    {% endsql %}
+
+    {% assign totalGoal = 0 %}
+    {% assign totalRaised = 0 %}
+    {% for member in members %}
+        {% assign totalGoal = totalGoal | Plus:member.FundraisingGoal %}
+        {% assign totalRaised = totalRaised | Plus:member.AmountRaised %}
+    {% endfor %}
+    {% assign totalPercent = totalRaised | DividedBy:totalGoal,2 | Times:100 | AtMost:100 %}
+
+    <div class="panel panel-block overflow-hidden">
+        <div class="bg-gray-lighter padding-t-md padding-l-md padding-r-md padding-b-sm">
+            <div class="clearfix">
+                <p class="pull-right">{{ totalRaised | FormatAsCurrency | Replace:'.00','' }} <span class="italic">of</span> <strong>{{ totalGoal | FormatAsCurrency | Replace:'.00','' }}</strong></p>
+                <h3 class="h4">Total Progress</h3>
+            </div>
+
+            {[ progressBar percent:'{{ totalPercent }}' striped:'true' ]}
+
+            <div class="progress hidden">
+                <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{ totalPercent }}" aria-valuemin="0" aria-valuemax="100" style="min-width: 200px; width: {{ totalPercent }}%;">
+                    {{ totalPercent }}% Complete
+                </div>
+            </div>
+        </div>
+
+
+
+        <ul class="list-group">
+        {% for member in members %}
+            {% assign fundraisingGoal = member.FundraisingGoal | AsInteger %}
+            {% assign amountRaised = member.AmountRaised | AsInteger %}
+            {% assign percentRaised = amountRaised | DividedBy:fundraisingGoal,2 | Times:100 | AtMost:100 %}
+        <li class="list-group-item">
+            {% assign memberPerson = member.PersonId | PersonById %}
+            <div class="row">
+                <div class="col-xs-12 col-sm-12 col-md-12 soft-half-top">
+                    <p class="pull-right">{{ amountRaised | FormatAsCurrency | Replace:'.00','' }} <span class="italic">of</span> <span class="stronger">{{ fundraisingGoal | FormatAsCurrency | Replace:'.00','' }}</span></p>
+                    <h3 class="h4 push-half-bottom">{{ memberPerson.FullName }}</h3>
+                </div><div class="col-xs-12 col-sm-12 col-md-12">
+
+                    {[ progressBar percent:'{{ percentRaised }}' striped:'true' ]}
+
+                </div>
+            </div>
+        </li>
+        {% endfor %}
+        </ul>
+
+    </div>
+    </section>
+{% else %}
+    <p class="alert alert-danger">No GroupId specified.</p>
+{% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/progress-bar.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/progress-bar.lava
@@ -1,0 +1,6 @@
+{% assign percent = percent | AsInteger %}
+<div class="progress">
+  <div class="progress-bar {% if striped == 'true' %}progress-bar-striped{% endif %} {% if animated == 'true' %}active{% endif %} {% if colorstatus and colorstatus == 'true' %}{% if percent <= 20 %}bg-danger{% elseif percent <= 70 %}bg-warning{% else %}bg-primary{% endif %}{% else %}bg-primary{% endif %}" role="progressbar" aria-valuenow="{{ percent }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ percent }}%;">
+    <span class="sr-only">{{ percent }}% Complete</span>
+  </div>
+</div>


### PR DESCRIPTION
## DESCRIPTION

This PR adds lava templates that replace the custom NewSpring fundraising blocks for our /missions pages. Implementing these templates on our missions pages will enable us to eliminate all custom NewSpring blocks.

### How do I test this PR?
1. Pull this branch down and check it out in a local dev environment
2. Change your web.connectionstrings.config file to point at `Brian` as the initial catalog

The following pages should look similar to/provide the same level of functionality as their production counterparts.
- [ ] Trip Page: https://brian.newspring.cc/missions/1754148
- [ ] Leader Toolbox: https://brian.newspring.cc/missions/1754148/leader
- [ ] Participant Page: https://brian.newspring.cc/missions/1754148/participant/4899321

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
