### PR TITLE
Updated page constrained functionality to not use javascript, to prevent the width 'jump' on page load

### DIFF
--- a/RockWeb/Themes/NewSpring/Layouts/Site.Master
+++ b/RockWeb/Themes/NewSpring/Layouts/Site.Master
@@ -81,11 +81,25 @@
                 <Rock:Zone Name="Header" runat="server" />
             </div>
 
+            <Rock:Lava ID="PageConstrained" runat="server">
+                {% assign isPageConstrained = CurrentPage | Attribute:'PageConstrained' %}
+                {% if isPageConstrained == 'Yes' %}
+                    <div class="page-constrained mx-auto">
+                {% endif %}
+            </Rock:Lava>
+
             <div id="content" class="clearfix">
                 <asp:ContentPlaceHolder ID="feature" runat="server"></asp:ContentPlaceHolder>
                 <asp:ContentPlaceHolder ID="main" runat="server"></asp:ContentPlaceHolder>
                 <Rock:Zone Name="Footer" runat="server" />                
             </div>
+
+            <Rock:Lava ID="PageConstrainedClose" runat="server">
+                {% assign isPageConstrained = CurrentPage | Attribute:'PageConstrained' %}
+                {% if isPageConstrained == 'Yes' %}
+                    </div>
+                {% endif %}
+            </Rock:Lava>
 
             <%-- controls for scriptmanager and update panel --%>
             <asp:ScriptManager ID="sManager" runat="server"/>


### PR DESCRIPTION
## DESCRIPTION

Currently, pages on our websites that have their width constrained do so by way of some javascript that exists in one of the blocks at the top of the page.
```
{% assign hasRights = 'Global' | Page:'Id' | HasRightsTo:'Edit','Rock.Model.Page' %}
{% assign pageconstrained = CurrentPage | Attribute:'PageConstrained' %}

<script>
    $(document).ready(function(){
    
        {% if pageconstrained == 'Yes' %}
            $('#content').addClass('page-constrained mx-auto');
        {% endif %}
    
        {% if hasRights == 'True' %}
            $('body').addClass('is-admin');
        {% endif %}
        
    });
</script>
```

This solution works, but because it runs after the elements are already visible on the page, there is a visible "jump" that happens when the page snaps to constrained width.

This PR implements a solution using lava that ensures constrained pages are actually constrained from the server itself.

### How do I test this PR?

1. Open https://newspring.cc/groups (constrained page) in an incognito window, and see how when the page loads, it loads full-width and then "snaps" to a constrained width
2. Pull down this branch on any local environment
3. Point web.connectionstrings.config file to Initial Catalog of `Brian`
4. Visit /groups on your local environment
5. Verify loading of the page as this width "snap" eliminated

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
