### PR TITLE
Removed resources from group leader hub landing page, added back to group button on attendance history page

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-attendance-list.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-attendance-list.lava
@@ -40,11 +40,17 @@
 
   {% assign occurrencesCount = occurrences | Size %}
 
-  {% capture addButton %}<p class="sm-push-half-bottom xs-push-half-bottom"><a href="{{ currentUrl }}/detail" class="btn btn-primary sm-btn-block xs-btn-block shadowed"><i class="fal fa-plus-circle push-quarter-right"></i> Add Attendance</a></p>{% endcapture %}
+
+  {% capture actionButtons %}
+    <p class="sm-push-half-bottom xs-push-half-bottom">
+      <a href="{{ currentUrl }}/detail" class="btn btn-primary sm-btn-block xs-btn-block sm-push-half-bottom xs-push-half-bottom shadowed"><i class="fal fa-plus-circle push-quarter-right"></i> Add Attendance</a>
+      <a href="/groups/{{ groupId }}/toolbox" class="btn btn-primary sm-btn-block xs-btn-block shadowed"><i class="fal fa-chevron-left push-quarter-right"></i> Back to Group</a>
+    </p>
+  {% endcapture %}
 
   {% if occurrencesCount and occurrencesCount >= 1 %}
 
-    {{ addButton }}
+    {{ actionButtons }}
 
     {% for occurrence in occurrences %}
 
@@ -117,7 +123,7 @@
 
     {% endfor %}
 
-    {{ addButton }}
+    {{ actionButtons }}
 
   {% else %}
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-attendance-list.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-attendance-list.lava
@@ -43,14 +43,16 @@
 
   {% capture actionButtons %}
     <p class="sm-push-half-bottom xs-push-half-bottom">
+    {% if occurrencesCount and occurrencesCount >= 1 %}
       <a href="{{ currentUrl }}/detail" class="btn btn-primary sm-btn-block xs-btn-block sm-push-half-bottom xs-push-half-bottom shadowed"><i class="fal fa-plus-circle push-quarter-right"></i> Add Attendance</a>
+    {% endif %}
       <a href="/groups/{{ groupId }}/toolbox" class="btn btn-primary sm-btn-block xs-btn-block shadowed"><i class="fal fa-chevron-left push-quarter-right"></i> Back to Group</a>
     </p>
   {% endcapture %}
 
-  {% if occurrencesCount and occurrencesCount >= 1 %}
+  {{ actionButtons }}
 
-    {{ actionButtons }}
+  {% if occurrencesCount and occurrencesCount >= 1 %}
 
     {% for occurrence in occurrences %}
 
@@ -132,6 +134,6 @@
       <p class="flush"><a href="{{ currentUrl }}/detail" class="btn btn-primary sm-btn-block xs-btn-block shadowed"><i class="fal fa-plus-circle push-quarter-right"></i> Take Attendance</a></p>
     {[ endcardBlock ]}
 
-  {% endif %}
+    {% endif %}
 
 {% endif %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
@@ -256,6 +256,7 @@ ORDER BY g2.Name, p.LastName, p.NickName
 {% comment %}
   Group Leader Resources
 {% endcomment %}
+{%- comment -%}
 {% if groups != empty or leaders != empty or coaches != empty %}
   {% contentchannelitem where:'ContentChannelId == 714' limit:'3' sort:'StartDateTime desc' iterator:'items' %}
     {% if items and items != empty %}
@@ -298,7 +299,7 @@ ORDER BY g2.Name, p.LastName, p.NickName
         </div>{% endfor %}
       </div>
 
-      {% comment %} <p class="xs-push-half-bottom"><a href="/groups/resources" class="btn xs-btn-block btn-primary shadowed"><i class="fas fa-sm fa-book push-quarter-right"></i> View More Resources</a></p> {% endcomment %}
     {% endif %}
   {% endcontentchannelitem %}
 {% endif %}
+{%- endcomment -%}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR removes the group resources section from the bottom of the group leader hub landing page, and adds a back to group button on attendance history page (per request from Fuse).

### How do I test this PR?

https://brian.newspring.cc/account/groups

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
