### PR TITLE
Added SQL file for giving history page

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/DATA/giving-history.sql
+++ b/RockWeb/Themes/NewSpring/assets/Lava/DATA/giving-history.sql
@@ -1,0 +1,99 @@
+-- DECLARE @StartDate AS NVARCHAR(MAX) = '01/01/20';
+-- DECLARE @EndDate AS NVARCHAR(MAX) = '12/31/20';
+
+DECLARE @EntityId AS NVARCHAR(MAX);
+DECLARE @PersonId AS INT = {{ CurrentPerson.Id }};
+DECLARE @GivingGroupId AS INT;
+
+-- default start date is a year ago
+IF ISDATE(@StartDate) = 0
+BEGIN
+    SELECT @StartDate = DATEADD(yy, DATEDIFF(yy, 0, GETDATE()), 0)
+END;
+
+-- default end date is today
+IF ISDATE(@EndDate) = 0
+BEGIN
+    SELECT @EndDate = GETDATE()
+END;
+
+-- set entity id based on business id being present
+IF @BusinessId > 0
+    BEGIN
+        SET @EntityId = @BusinessId;
+    END;
+ELSE
+    BEGIN
+        SET @EntityId = @PersonId;
+    END;
+
+-- set giving group id based on entity
+SET @GivingGroupId = (
+    SELECT GivingGroupId
+    FROM Person p
+    WHERE p.Id = @EntityId
+)
+
+-- get transactions
+IF(ISNULL(@GivingGroupId, null) IS null)
+    SELECT *
+    FROM FinancialTransaction ft
+    JOIN PersonAlias pa
+    ON ft.AuthorizedPersonAliasId = pa.Id
+    JOIN Person p
+    ON pa.PersonId = p.Id
+    JOIN FinancialTransactionDetail ftd
+    ON ftd.TransactionId = ft.Id
+    JOIN FinancialAccount fa
+    ON ftd.AccountId = fa.Id
+    JOIN FinancialAccount pfa
+    ON fa.ParentAccountId = pfa.Id
+    WHERE ft.AuthorizedPersonAliasId IN
+    (
+        SELECT pa.Id
+        FROM PersonAlias pa
+        WHERE pa.PersonId = @EntityId
+    )
+    AND ft.TransactionDateTime >= @StartDate
+    AND ft.TransactionDateTime <= @EndDate
+    AND pfa.IsTaxDeductible = 1
+    ORDER BY ft.TransactionDateTime DESC
+ELSE
+    SELECT *
+    FROM FinancialTransaction ft
+    JOIN PersonAlias pa
+    ON ft.AuthorizedPersonAliasId = pa.Id
+    JOIN Person p
+    ON pa.PersonId = p.Id
+    JOIN FinancialTransactionDetail ftd
+    ON ftd.TransactionId = ft.Id
+    JOIN FinancialAccount fa
+    ON ftd.AccountId = fa.Id
+    JOIN FinancialAccount pfa
+    ON fa.ParentAccountId = pfa.Id
+    WHERE ft.AuthorizedPersonAliasId IN
+    (
+        SELECT pa.Id
+        FROM GroupMember gm
+        JOIN Person p
+        ON gm.PersonId = p.Id
+        JOIN PersonAlias pa
+        ON pa.PersonId = p.Id
+        WHERE GroupId IN (
+            SELECT g.Id
+            FROM GroupMember gm
+            JOIN [Group] g
+            ON gm.GroupId = g.Id
+            WHERE gm.PersonId = @EntityId
+            AND g.GroupTypeId = 10
+        ) AND
+        (
+            p.GivingGroupId = @GivingGroupId
+            OR
+            p.AgeClassification = 2
+        )
+    )
+    AND ft.TransactionDateTime >= @StartDate
+    AND ft.TransactionDateTime <= @EndDate
+    AND pfa.IsTaxDeductible = 1
+    ORDER BY ft.TransactionDateTime DESC

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/giving-history.lava
@@ -17,6 +17,7 @@
         AND gm.GroupRoleId = 25
     )
     AND gm2.PersonId != {{ CurrentPerson.Id }}
+    AND gm2.GroupRoleId = 5
 {% endsql %}
 
 {% assign businessesCount = businessIds | Size %}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This SQL fixes an issue on the giving history page where a person's transactions are not visible if they do not have their GivingGroupId set.

### How do I test this PR?
1. Checkout the `giving-history` branch and rebuild the Rock solution in VIsual Studio.
2. Go to the [giving history page](http://brandon.newspring.cc/give/history) on your dev vm, and verify the following configuration on the dynamic data block:
- Query field should contain `{% include '~~/Assets/Lava/DATA/giving-history.sql' %}`.
- Parameters `StartDate=;EndDate=;BusinessId=;`
- Formatted Output `{% include '~/Themes/NewSpring/Assets/Lava/LAYOUT/giving-history.lava' %}`

3. Impersonate and verify the following people can successfully view their giving history:
- [x] People w/no GivingGroupId (PersonId 346065).
- [x] People w/a GivingGroupId (PersonId 106107).
- [x] People w/Business Transactions can successfully view both their personal AND business giving transactions (PersonId 437981,412275).

4. Once verifying all these scenarios are working, approve this PR, and then replace the `ready for review` label with the `merge` label.

## TODO
- [X] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [X] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [ ] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
