### PR TITLE
Updated locations lava templates for Eastlan updates

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/DATA/service-times.lava
@@ -1,6 +1,7 @@
 {% if campusid and campusid != empty %}
     {% campus id:'{{ campusid }}' iterator:'campuses' %}
         {% for campus in campuses %}
+            {% assign campusSlug = campus.Name | Replace:' ','-' | Downcase %}
             {% capture servicesJSON %}{{ campus | Attribute:'ServiceTimes1' }}{% endcapture %}
         {% endfor %}
     {% endcampus %}
@@ -10,7 +11,7 @@
     {% for service in servicesJSON %}
         {% if service.ServiceType == servicetype %}
             {% if service.ServiceLabel != empty %}<strong>{{ service.ServiceLabel }}</strong> {% if service.DoorsOpenTime != empty or service.PickUpTime != empty %}<i class="fa fa-info-circle text-info " style="margin-top: 3px;" data-toggle="tooltip" data-placement="top" title="{% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}Doors Open - {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.PickUpTime and service.PickUpTime != empty %}Pick Up Students - {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %}"></i>{% endif %}<br>{% endif %}
-            {{ service.ServiceDay }} {{ service.ServiceTime | Remove:':00' | Remove:' ' | Downcase }} {% if service.ServiceLabel == '' and service.DoorsOpenTime != empty or service.PickUpTime != empty %}<i class="fa fa-info-circle text-info " style="margin-top: 3px;" data-toggle="tooltip" data-placement="top" title="{% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}Doors Open - {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.PickUpTime and service.PickUpTime != empty %}Pick Up Students - {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %}"></i>{% endif %}
+            {{ service.ServiceDay }} {% if campusSlug == 'eastlan' %}{{ service.ServiceTime | Replace:':15',':30' | Remove:':00' | Remove:' ' | Downcase }}{% else %}{{ service.ServiceTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.ServiceLabel == '' and service.DoorsOpenTime != empty or service.PickUpTime != empty %}<i class="fa fa-info-circle text-info " style="margin-top: 3px;" data-toggle="tooltip" data-placement="top" title="{% if service.DoorsOpenTime and service.DoorsOpenTime != empty %}Doors Open - {{ service.DoorsOpenTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %} {% if service.PickUpTime and service.PickUpTime != empty %}Pick Up Students - {{ service.PickUpTime | Remove:':00' | Remove:' ' | Downcase }}{% endif %}"></i>{% endif %}
             {% if service.ServiceNote and service.ServiceNote != empty %}<br>{{ service.ServiceNote | Replace:"'","’" }}{% endif %}
             {% if service.ServiceLocation.Street1 != empty %}
                 {% capture serviceLocationAddress %}{{ service.ServiceLocation.Street1 }} {% if service.ServiceLocation.Street2 != empty %}{{ service.ServiceLocation.Street2 }} {% endif %}{{ service.ServiceLocation.City }} {{ service.ServiceLocation.State }} {{ service.ServiceLocation.PostalCode }}{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -1,4 +1,4 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
 
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
@@ -15,7 +15,7 @@
 {% capture id %}{% endcapture %}
 {% capture title %}{% if servicetype != 'Fuse' %}{{ 'Global' | Attribute:'OrganizationName' }}{% else %}Fuse Student Ministry{% endif %}{% endcapture %}
 {% capture titlesize %}{% endcapture %}
-{% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name }}, SC</h3>{% endcapture %}
+{% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name | Replace:'Eastlan','Greenville' }}, SC</h3>{% endcapture %}
 {% capture textalignment %}{% endcapture %}
 {% capture label %}{% endcapture %}
 {% capture subtitle %}{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -1,4 +1,4 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 {% assign mailingAddress = campus.MailingAddress %}
 {% assign officeAddress = campus.OfficeAddress %}
@@ -14,7 +14,7 @@
     <div class="row {% if servicetype == 'Fuse' %}row-reverse{% endif %} soft-double-sides xs-soft-half-sides xs-text-center sm-text-center">
         <div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype != 'Fuse' %}push-bottom{% endif %}">
             <h3 class="push-half-bottom">Sunday Gatherings</h3>
-            <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.</small></p>
+            <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for the {{ campus.Name }} location of NewSpring Church.{% if campusSlug == 'Rock Hill' %} We will be gathering outdoors. Please bring a chair.{% elseif campusSlug == 'Eastlan' %} <a href="/kidspring">KidSpring</a> is open during the 9:30am and 11:30am gatherings.{% endif %}</small></p>
             <p class="lead">{{ serviceTimes }}
             {% if getDirections != empty %}
                 <a href="{{ getDirections }}" >Get Directions</a>
@@ -22,7 +22,7 @@
             </p>
         </div>{% if fuseServiceTimes != empty and fuseServiceTimes != '' %}<div class="col-xs-12 col-sm-12 col-md-6 {% if servicetype == 'Fuse' %}push-bottom{% endif %}">
             <h3 class="push-half-bottom">Fuse Student Ministry</h3>
-            <p class="push-half-bottom" style="max-width: 400px;"><small>Weekly gathering times for Fuse &mdash; the Student Ministry of NewSpring Church.</small></p>
+            <p class="push-half-bottom" style="max-width: 400px;"><small>Fuse is happening in-person and online every Wednesday. Watch as a family or connect to a Fuse Group.<br><a href="/fuse?utm_source=newspring&utm_medium=text&utm_campaign=locations">Learn More</a></small></p>
             <p class="lead">{{ fuseServiceTimes }}</p>
         </div>{% endif %}
     </div>
@@ -44,7 +44,7 @@
 
             {% if officeAddress.Street1 != null and officeAddress.Street1 != '' and officeAddress.Street1 != location.Street1 %}
                 <h3 class="push-half-bottom">Office Address</h3>
-                <p class="lead"> 
+                <p class="lead">
                     {{ officeAddress.Street1 }}<br>
                     {% if officeAddress.Street2 != empty %}
                         {{ officeAddress.Street2 }}<br>
@@ -66,7 +66,8 @@
 
         </div><div class="col-xs-12 col-sm-12 col-md-4">
             <h3 class="push-half-bottom">Phone</h3>
-            <p class="lead"><a href="tel:+1{{ campus.PhoneNumber | Remove:'-' }}">({{ campus.PhoneNumber | Slice:0,3 }}) {{ campus.PhoneNumber | Slice:4,9 }}</a></p>
+            {% assign phoneNumber = campus.PhoneNumber | Remove:'(' | Remove:')' | Remove:'-' | Remove:' ' %}
+            <p class="lead"><a href="tel:+1{{ phoneNumber }}">({{ phoneNumber | Slice:0,3 }}) {{ phoneNumber | Slice:3,3 }}-{{ phoneNumber | Slice:6,4 }}</a></p>
         </div><div class="col-xs-12 col-sm-12 col-md-4">
             <h3 class="push-half-bottom">Email</h3>
             <p class="lead"><a href="mailto:{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc">{{ campus.Name | Downcase | Remove:' ' }}@newspring.cc</a></p>

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -1,4 +1,4 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
 {% if servicetype == 'Fuse' %}
@@ -8,8 +8,8 @@
 {% endif %}
 
 {% if campus.campusStaff != empty %}
-{[ section title:'{{ campus.Name }} Staff' ]}
-        
+{[ section title:'{{ campus.Name }} Campus Staff' ]}
+
     {% if leader != null %}
     <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
         <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-swiper.lava
@@ -10,7 +10,7 @@
       {% capture content %}
         <p class="push-half-bottom">{[ serviceTimes campusid:'{{ campus.Id }}' servicetype:'{{ servicetype }}' ]}</p>
       {% endcapture %}
-      {[ card type:'Location' title:'{{ campus.Name }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
+      {[ card type:'Location' title:'{{ campus.Name | Replace:'Eastlan','Greenville' }}' titlesize:'h3' linktext:'Campus Details' linkurl:'{% if servicetype == 'Fuse' %}/fuse{% endif %}/locations/{{ campus.Name | Replace:' ','-' | Downcase | Replace:'eastlan','greenville' }}' imageurl:'{{ campusImageUrl | Trim }}' content:'{% if content and content != empty %}{{ content }}{% endif %}' ]}
     [[ enditem ]]
   {% endfor %}
 {[ endswiper ]}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR updates the locations lava templates to account for renaming the Greenville Campus to Eastlan in Rock, per [this document.](https://docs.google.com/document/d/1W4VFO-0Mt-GqeQaT0STXuVlN2brMFPVk-Irz-u8kWTk/edit)

### How do I test this PR?
- Pull this branch down to a test environment.
- Point `Initial Catalog` in web.connectionstrings.config to `Brian`
- Verify the changes listed in the [document](https://docs.google.com/document/d/1W4VFO-0Mt-GqeQaT0STXuVlN2brMFPVk-Irz-u8kWTk/edit) have been made.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
