### PR TITLE
Added lava to write interactions to the parent component of entry pages

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -67,6 +67,12 @@
         {% assign parentImage = parentItem.ImageLandscape %}
         {% capture parentPermalink %}{[ getPermalink cciid:'{{ parentItem.Id }}' ]}{% endcapture %}
         {% assign totalChildren = parentItem.Children | Size %}
+
+        {% comment %}
+            Write parent interaction
+        {% endcomment %}
+        {% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ parentItem.ChannelId }}' channelname:'{{ parentItem.ChannelName }}' componententitytypeid:'209' componententityid:'{{ parentItem.Id }}' componentname:'{{ parentItem.Title }}' operation:'View' summary:'Viewed "{{ parentItem.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+
     {% endif %}
 
     {% comment %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/sermon-detail.lava
@@ -41,6 +41,12 @@
         {% assign backgroundColor = parentItem.BackgroundColor %}
         {% assign parentVideo = parentItem.Video %}
         {% assign parentUrl = parentItem.Permalink %}
+
+        {% comment %}
+            Write parent interaction
+        {% endcomment %}
+        {% interactionwrite channeltypemediumvalueid:'906' channelentityid:'{{ parentItem.ChannelId }}' channelname:'{{ parentItem.ChannelName }}' componententitytypeid:'209' componententityid:'{{ parentItem.Id }}' componentname:'{{ parentItem.Title }}' operation:'View' summary:'Viewed "{{ parentItem.Title }}"' channelcustom1:'{{ siteId }}' personaliasid:'{{ CurrentPerson.PrimaryAliasId }}' source:'{{ source }}' medium:'{{ medium }}' campaign:'{{ campaign }}' %}{{ currentUrl }}{% endinteractionwrite %}
+
     {% endif %}
 
     {% assign pagePath = 'Global' | Page:'Path' %}


### PR DESCRIPTION
## DESCRIPTION
This PR adds a couple of lines of lava to the editorial/sermon entry lava templates that writes interactions to the collection of the item being viewed (for devotionals, writes interactions to the study component, sermons writes to series, etc).

### How do I test this PR?
- Checkout this branch.
- View any devotional/sermon page on newspring.cc
- Interactions should be written to both the devotional component, as well as the study component that correlates with that devo's study.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
