### PR TITLE
Add Daily Totals to Weekly Metrics Dashboards

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/weekly-metrics-dashboard.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/weekly-metrics-dashboard.lava
@@ -100,13 +100,13 @@
     AND ao.ScheduleId IS NOT NULL
     AND ao.OccurrenceDate > DATEADD(WEEK, -12, @Now)
     AND ao.OccurrenceDate <= @Now
-    AND ao.ScheduleId IN (12,13) -- limit results to 9:15 & 11:15
+    AND ao.ScheduleId IN (5330,12,13) -- limit results to 9:15 & 11:15
     ORDER BY CONVERT(varchar, ao.OccurrenceDate, 23) DESC, g.CampusId ASC, ao.ScheduleId ASC
 {% endsql %}
 
 
 <!-- SETUP CAMPUS PICKER -->
-{% campus where:'IsActive == true && Public == "Y"' iterator:'campuses' %}
+{% campus where:'IsActive == true && Public == "Y"' iterator:'campuses' order:''%}
     {% assign campuses = campuses %}
 {% endcampus %}
 
@@ -144,6 +144,16 @@
     "Date": "{{ date.Date }}",
     "Schedules": [
         {
+            "Id": "5330",
+            "Campuses": [
+            {% for campus in campuses %}{
+                "Name": {{ campus.Name | ToJSON }},
+                "AdultAttendance": {{ adultAttendanceValues | Where:'Date',date.Date | Where:'ScheduleId',5330 | Where:'CampusId',campus.Id | First | Property:'AdultAttendance' | AsInteger | ToJSON }},
+                "VolunteerAttendance": {{ values | Where:'Date',date.Date | Where:'ScheduleId',5330 | Where:'CampusId',campus.Id | First | Property:'VolunteerAttendance' | ToJSON }},
+                "KidSpringAttendance": {{ values | Where:'Date',date.Date | Where:'ScheduleId',5330 | Where:'CampusId',campus.Id | First | Property:'KidSpringAttendance' | ToJSON }}
+            }{% unless forloop.last %},{% endunless %}{% endfor %}
+            ]
+        },{
             "Id": "12",
             "Campuses": [
             {% for campus in campuses %}{
@@ -172,11 +182,25 @@
 {% assign currentWeekString = now | Date:'yyyy-MM-dd' | AsString %}
 {% assign previousWeekString = now | DateAdd:-7 | Date:'yyyy-MM-dd' | AsString %}
 
+{% assign currentWeek0800 = valuesObject | Where:'Date',currentWeekString | First | Property:'Schedules' | Where:'Id','5330' | First | Property:'Campuses' %}
 {% assign currentWeek0915 = valuesObject | Where:'Date',currentWeekString | First | Property:'Schedules' | Where:'Id','12' | First | Property:'Campuses' %}
 {% assign currentWeek1115 = valuesObject | Where:'Date',currentWeekString | First | Property:'Schedules' | Where:'Id','13' | First | Property:'Campuses' %}
 
+{% assign previousWeek0800 = valuesObject | Where:'Date',previousWeekString | First | Property:'Schedules' | Where:'Id','5330' | First | Property:'Campuses' %}
 {% assign previousWeek0915 = valuesObject | Where:'Date',previousWeekString | First | Property:'Schedules' | Where:'Id','12' | First | Property:'Campuses' %}
 {% assign previousWeek1115 = valuesObject | Where:'Date',previousWeekString | First | Property:'Schedules' | Where:'Id','13' | First | Property:'Campuses' %}
+
+<!-- Set Current Week 800 Values -->
+{% assign current800Adults = 0 %}
+{% assign current800Kids = 0 %}
+{% assign current800Vols = 0 %}
+{% for campus in currentWeek0800 %}
+    {% if currentCampus == empty or currentCampus != empty and currentCampus == campus.Name %}
+        {% assign current800Adults = current800Adults | Plus:campus.AdultAttendance %}
+        {% assign current800Kids = current800Kids | Plus:campus.KidSpringAttendance %}
+        {% assign current800Vols = current800Vols | Plus:campus.VolunteerAttendance %}
+    {% endif %}
+{% endfor %}
 
 <!-- Set Current Week 915 Values -->
 {% assign current915Adults = 0 %}
@@ -199,6 +223,18 @@
         {% assign current1115Adults = current1115Adults | Plus:campus.AdultAttendance %}
         {% assign current1115Kids = current1115Kids | Plus:campus.KidSpringAttendance %}
         {% assign current1115Vols = current1115Vols | Plus:campus.VolunteerAttendance %}
+    {% endif %}
+{% endfor %}
+
+<!-- Set Previous Week 800 Values -->
+{% assign previous800Adults = 0 %}
+{% assign previous800Kids = 0 %}
+{% assign previous800Vols = 0 %}
+{% for campus in previousWeek0800 %}
+    {% if currentCampus == empty or currentCampus != empty and currentCampus == campus.Name %}
+        {% assign previous800Adults = previous800Adults | Plus:campus.AdultAttendance %}
+        {% assign previous800Kids = previous800Kids | Plus:campus.KidSpringAttendance %}
+        {% assign previous800Vols = previous800Vols | Plus:campus.VolunteerAttendance %}
     {% endif %}
 {% endfor %}
 
@@ -227,13 +263,28 @@
 {% endfor %}
 
 <!-- Set Total Attendance Values -->
+{% assign current800Total = current800Adults | Plus:current800Kids %}
+{% assign previous800Total = previous800Adults | Plus:previous800Kids %}
+
 {% assign current915Total = current915Adults | Plus:current915Kids %}
 {% assign previous915Total = previous915Adults | Plus:previous915Kids %}
 
 {% assign current1115Total = current1115Adults | Plus:current1115Kids %}
 {% assign previous1115Total = previous1115Adults | Plus:previous1115Kids %}
 
+{% assign currentTotalKids = current800Kids | Plus:current915Kids | Plus:current1115Kids %}
+{% assign currentTotalAdults = current800Adults | Plus:current915Adults | Plus:current1115Adults %}
+
+{% assign previousTotalKids = previous800Kids | Plus:previous915Kids | Plus:previous1115Kids %}
+{% assign previousTotalAdults = previous800Adults | Plus:previous915Adults | Plus:previous1115Adults %}
+{% assign previousTotalVols = previous800Vols | Plus:previous915Vols | Plus:previous1115Vols %}
+{% assign previousTotal = previous800Total | Plus:previous915Total | Plus:previous1115Total %}
+
 <!-- Set Change Values -->
+{% assign 800AdultsChange = current800Adults | Minus:previous800Adults %}
+{% assign 800VolsChange = current800Vols | Minus:previous800Vols %}
+{% assign 800TotalChange = current800Total | Minus:previous800Total %}
+
 {% assign 915AdultsChange = current915Adults | Minus:previous915Adults %}
 {% assign 915VolsChange = current915Vols | Minus:previous915Vols %}
 {% assign 915TotalChange = current915Total | Minus:previous915Total %}
@@ -243,6 +294,9 @@
 {% assign 1115TotalChange = current1115Total | Minus:previous1115Total %}
 
 <!-- Set KidSpring Percentage Values -->
+{% if current800Adults > 0 %}
+    {% assign 800KidsPercentage = current800Kids | DividedBy:current800Adults,4 | Times:100 | Format:'###.##' %}
+{% endif %}
 {% if current915Adults > 0 %}
     {% assign 915KidsPercentage = current915Kids | DividedBy:current915Adults,4 | Times:100 | Format:'###.##' %}
 {% endif %}
@@ -250,6 +304,7 @@
     {% assign 1115KidsPercentage = current1115Kids | DividedBy:current1115Adults,4 | Times:100 | Format:'###.##' %}
 {% endif %}
 
+{% assign dailyKidsPercentage =  %}
 
 <!-- LAYOUT -->
 <div class="push-bottom"><span class="h1 stronger">{{ now | Date:'MMMM d, yyyy' }} - {% if currentCampus and currentCampus != empty %}{{ currentCampus }}{% else %}All Campuses{% endif %}</span><span class="pull-right">{{ campusPicker }}</span></div>
@@ -257,61 +312,150 @@
 <div class="row">
     <div class="col-md-3 col-sm-6 col-xs-12">
         {[ rockCard title:'Total Attendance' iconclass:'' ]}
-        <div class="metric">
-            <h6 class="push-quarter-bottom">9:15 Gathering</h6>
-            <h1>{{ current915Total | Format:'###,###,###' | WithFallback:'', '-' }}
-            <span class="badge {% if 915TotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous915Total | Format:'###,###,###' }}">{% if 915TotalChange > 0 %}+{% endif %}{{ 915TotalChange | Format:'###,###,###' }}</span></h1>
-        </div>
-        <div class="metric">
-            <h6 class="push-quarter-bottom">11:15 Gathering</h6>
-            <h1>{{ current1115Total | Format:'###,###,###' | WithFallback:'', '-' }}
-            <span class="badge {% if 1115TotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous1115Total | Format:'###,###,###' }}">{% if 1115TotalChange > 0 %}+{% endif %}{{ 1115TotalChange | Format:'###,###,###' }}</span></h1>
-        </div>
+
+            {% if currentCampus == 'Eastlan' or currentCampus == empty %}
+                <div class="metric">
+                    <h6 class="push-quarter-bottom">8:00 Gathering</h6>
+                    <h1>{{ current800Total | Format:'###,###,###' | WithFallback:'', '0' }}
+                    <span class="badge {% if 800TotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous800Total | Format:'###,###,###' }}">{% if 800TotalChange > 0 %}+{% endif %}{{ 800TotalChange | Format:'###,###,###' }}</span></h1>
+                </div>
+            {% endif %}
+
+            <div class="metric">
+                <h6 class="push-quarter-bottom">9:15 Gathering</h6>
+                <h1>{{ current915Total | Format:'###,###,###' | WithFallback:'', '0' }}
+                <span class="badge {% if 915TotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous915Total | Format:'###,###,###' }}">{% if 915TotalChange > 0 %}+{% endif %}{{ 915TotalChange | Format:'###,###,###' }}</span></h1>
+            </div>
+
+            <div class="metric">
+                <h6 class="push-quarter-bottom">11:15 Gathering</h6>
+                <h1>{{ current1115Total | Format:'###,###,###' | WithFallback:'', '0' }}
+                <span class="badge {% if 1115TotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous1115Total | Format:'###,###,###' }}">{% if 1115TotalChange > 0 %}+{% endif %}{{ 1115TotalChange | Format:'###,###,###' }}</span></h1>
+            </div>
+
+            <hr>
+
+            {% assign dailyTotal = current800Total | Plus:current915Total | Plus:current1115Total %}
+            {% assign dailyTotalChange = 800TotalChange | Plus:915TotalChange | Plus:1115TotalChange %}
+            <div class="metric">
+                <h6 class="push-quarter-bottom">Daily Total</h6>
+                <h1>{{ dailyTotal | Format:'###,###,###' | WithFallback:'', '0' }}
+                <span class="badge {% if dailyTotalChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previousTotal | Format:'###,###,###' }}">{% if dailyTotalChange > 0 %}+{% endif %}{{ dailyTotalChange | Format:'###,###,###' }}</span></h1>
+            </div>
+
         {[ endrockCard ]}
     </div><div class="col-md-3 col-sm-6 col-xs-12">
         {[ rockCard title:'Adult Attendance' iconclass:'' ]}
+
+            {% if currentCampus == 'Eastlan' or currentCampus == empty %}
+                <div class="metric">
+                    <h6 class="push-quarter-bottom">8:00 Gathering</h6>
+                    <h1>{{ current800Adults | Format:'###,###,###' | WithFallback:'', '0' }}
+                    <span class="badge {% if 800AdultsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous800Adults | Format:'###,###,###' }}">{% if 800AdultsChange > 0 %}+{% endif %}{{ 800AdultsChange | Format:'###,###,###' }}</span></h1>
+                </div>
+            {% endif %}
+
             <div class="metric">
                 <h6 class="push-quarter-bottom">9:15 Gathering</h6>
-                <h1>{{ current915Adults | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current915Adults | Format:'###,###,###' | WithFallback:'', '0' }}
                 <span class="badge {% if 915AdultsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous915Adults | Format:'###,###,###' }}">{% if 915AdultsChange > 0 %}+{% endif %}{{ 915AdultsChange | Format:'###,###,###' }}</span></h1>
             </div>
             <div class="metric">
                 <h6 class="push-quarter-bottom">11:15 Gathering</h6>
-                <h1>{{ current1115Adults | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current1115Adults | Format:'###,###,###' | WithFallback:'', '0' }}
                 <span class="badge {% if 1115AdultsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous1115Adults | Format:'###,###,###' }}">{% if 1115AdultsChange > 0 %}+{% endif %}{{ 1115AdultsChange | Format:'###,###,###' }}</span></h1>
             </div>
+
+            <hr>
+
+            {% assign dailyTotalAdults = current800Adults | Plus:current915Adults | Plus:current1115Adults %}
+            {% assign dailyTotalChangeAdults = 800AdultsChange | Plus:915AdultsChange | Plus:1115AdultsChange %}
+            <div class="metric">
+                <h6 class="push-quarter-bottom">Daily Total</h6>
+                <h1>{{ dailyTotalAdults | Format:'###,###,###' | WithFallback:'', '0' }}
+                <span class="badge {% if dailyTotalChangeAdults < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previousTotalAdults | Format:'###,###,###' }}">{% if dailyTotalChangeAdults > 0 %}+{% endif %}{{ dailyTotalChangeAdults | Format:'###,###,###' }}</span></h1>
+            </div>
+
         {[ endrockCard ]}
     </div><div class="col-md-3 col-sm-6 col-xs-12">
         {[ rockCard title:'KidSpring Attendance' iconclass:'' ]}
+
+            {% if currentCampus == 'Eastlan' or currentCampus == empty %}
+                <div class="metric">
+                    <h6 class="push-quarter-bottom">8:00 Gathering</h6>
+                    <h1>{{ current800Kids | Format:'###,###,###' | WithFallback:'', '0' }}
+                    {% if 800KidsPercentage %}
+                        <span class="badge">{{ 800KidsPercentage }}%</span>
+                    {% endif %}
+                    </h1>
+                </div>
+            {% endif %}
+
             <div class="metric">
                 <h6 class="push-quarter-bottom">9:15 Gathering</h6>
-                <h1>{{ current915Kids | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current915Kids | Format:'###,###,###' | WithFallback:'', '0' }}
                 {% if 915KidsPercentage %}
                     <span class="badge">{{ 915KidsPercentage }}%</span>
                 {% endif %}
                 </h1>
             </div>
+
             <div class="metric">
                 <h6 class="push-quarter-bottom">11:15 Gathering</h6>
-                <h1>{{ current1115Kids | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current1115Kids | Format:'###,###,###' | WithFallback:'', '0' }}
                 {% if 1115KidsPercentage %}
                     <span class="badge">{{ 1115KidsPercentage }}%</span>
                 {% endif %}
                 </h1>
             </div>
+
+            <hr>
+
+            {% assign dailyTotalKids = current800Kids | Plus:current915Kids | Plus:current1115Kids %}
+            {% assign dailyTotalAdults = current800Adults | Plus:current915Adults | Plus:current1115Adults %}
+            {% assign dailyTotalChangeKids = dailyTotalKids | DividedBy:dailyTotalAdults,4 | Times:100 | Format:'###.##' %}
+            <div class="metric">
+                <h6 class="push-quarter-bottom">Daily Total</h6>
+                <h1>{{ dailyTotalKids | Format:'###,###,###' | WithFallback:'', '0' }}
+                {% if dailyTotalChangeKids %}
+                    <span class="badge">{{ dailyTotalChangeKids }}%</span>
+                {% endif %}
+            </div>
+
         {[ endrockCard ]}
     </div><div class="col-md-3 col-sm-6 col-xs-12">
         {[ rockCard title:'Volunteer Attendance' iconclass:'' ]}
+
+            {% if currentCampus == 'Eastlan' or currentCampus == empty %}
+                <div class="metric">
+                    <h6 class="push-quarter-bottom">8:00 Gathering</h6>
+                    <h1>{{ current800Vols | Format:'###,###,###' | WithFallback:'', '0' }}
+                    <span class="badge {% if 800VolsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous800Vols | Format:'###,###,###' }}">{% if 800VolsChange > 0 %}+{% endif %}{{ 800VolsChange | Format:'###,###,###' }}</span></h1>
+                </div>
+            {% endif %}
+
             <div class="metric">
                 <h6 class="push-quarter-bottom">9:15 Gathering</h6>
-                <h1>{{ current915Vols | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current915Vols | Format:'###,###,###' | WithFallback:'', '0' }}
                 <span class="badge {% if 915VolsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous915Vols | Format:'###,###,###' }}">{% if 915VolsChange > 0 %}+{% endif %}{{ 915VolsChange | Format:'###,###,###' }}</span></h1>
             </div>
+
             <div class="metric">
                 <h6 class="push-quarter-bottom">11:15 Gathering</h6>
-                <h1>{{ current1115Vols | Format:'###,###,###' | WithFallback:'', '-' }}
+                <h1>{{ current1115Vols | Format:'###,###,###' | WithFallback:'', '0' }}
                 <span class="badge {% if 1115VolsChange < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previous1115Vols | Format:'###,###,###' }}">{% if 1115VolsChange > 0 %}+{% endif %}{{ 1115VolsChange | Format:'###,###,###' }}</span></h1>
             </div>
+
+            <hr>
+
+            {% assign dailyTotalVols = current800Vols | Plus:current915Vols | Plus:current1115Vols %}
+            {% assign dailyTotalChangeVols = 800VolsChange | Plus:915VolsChange | Plus:1115VolsChange %}
+            <div class="metric">
+                <h6 class="push-quarter-bottom">Daily Total</h6>
+                <h1>{{ dailyTotalVols | Format:'###,###,###' | WithFallback:'', '0' }}
+                <span class="badge {% if dailyTotalChangeVols < 0 %}bg-danger{% else %}bg-success{% endif %}" title="{{ previousWeekString | Date:'MMM d, yyyy' }} - {{ previousTotalVols | Format:'###,###,###' }}">{% if dailyTotalChangeVols > 0 %}+{% endif %}{{ dailyTotalChangeVols | Format:'###,###,###' }}</span></h1>
+            </div>
+
         {[ endrockCard ]}
     </div>
 </div>
@@ -326,6 +470,7 @@
                         <th>Services</th>
                         <th>Adult Attendance</th>
                         <th>KidSpring</th>
+                        <th>Daily Total</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -350,6 +495,7 @@
                             <td>{{ adultAttendanceValues | Where:'Date',currentWeekString | Where:'CampusId',campus.Id | Size }}</td>
                             <td>{{ campusAdultTotal | Format:'###,###,###' }}</td>
                             <td>{{ campusKidSpringTotal | Format:'###,###,###' }}</td>
+                            <td>{{ campusAdultTotal | Plus:campusKidSpringTotal | Format:'###,###,###' }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -374,7 +520,35 @@ var myChart = new Chart(ctx, {
         labels: [
             {% for date in dates %}'{{ date.Date | Date:"MMM d, yyyy" }}'{% unless forloop.last %},{% endunless %}{% endfor %}
         ],
-        datasets: [{
+        datasets: [{% if currentCampus == 'Eastlan' or currentCampus == empty %}{
+            label: '8:00 Gathering',
+            lineTension: .4,
+            borderWidth: 3,
+            fill: false,
+            data: [
+            {% for date in valuesObject reversed -%}
+                {%- assign totalAttendance = 0 -%}
+                {%- assign schedule = date.Schedules | Where:'Id','5330' | First -%}
+                {%- for campus in schedule.Campuses -%}
+                    {%- if currentCampus == empty or currentCampus != empty and currentCampus == campus.Name -%}
+                        {%- assign totalAttendance = totalAttendance | Plus:campus.AdultAttendance | Plus:campus.KidSpringAttendance -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {{ totalAttendance }}{% unless forloop.last %},{% endunless %}
+            {%- endfor %}
+            ],
+            borderColor: [
+                '#c64f55'
+            ],
+            pointHitRadius: 3,
+            pointRadius: 7,
+            pointHoverRadius: 12,
+            pointBorderWidth: 4,
+            pointHoverBorderWidth: 4,
+            pointBackgroundColor: '#c64f55',
+            pointBorderColor: '#fff',
+            pointHoverBorderColor: '#fff'
+        },{% endif %}{
             label: '9:15 Gathering',
             lineTension: .4,
             borderWidth: 3,


### PR DESCRIPTION
## DESCRIPTION

This PR... 
- updates the weekly metrics dashboard lava from prod-rock (include had been replaced with changes)
- adds daily total values to each card
- adds daily totals to the by-campus table

### How do I test this PR?
1. Checkout this branch in a test environment
2. View the Weekly Metrics Page in Rock - feel free to change the date in the url to anything that has attendance (https://brian-rock.newspring.cc/sundaymetrics?date=2019-08-30) 
3. Verify daily totals in cards are accurate and that their change/percentages are accurate.
4. Verify daily totals in the campus table at the bottom is accurate.
5. Verify the totals are accurate on an individual campus dashboard as well (https://brian-rock.newspring.cc/sundaymetrics?campus=anderson&date=2019-08-25)

![image](https://user-images.githubusercontent.com/2465823/104330374-ec006b00-54bb-11eb-8fa0-b2ea7b8568ae.png)

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
