### PR TITLE
Omitted coaching group members who are archived from the group leader hub lava template coaching section

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
@@ -84,6 +84,7 @@ WHERE gm.PersonId = {{ personId }}
 AND gm2.PersonId != {{ personId }} -- Omit Self From List
 AND g.GroupTypeId = 156 -- Coaching Group
 AND gm.GroupRoleId = 436 -- Is Coach
+AND gm.IsArchived = 0
 AND g.IsArchived = 0
 AND g.IsActive = 1
 AND gm2.GroupRoleId != 382


### PR DESCRIPTION
## DESCRIPTION

This PR updates the Group Leader Hub landing page lava to not show the coaching section for group coaches who have been archived.

### How do I test this PR?
- You may need to enable group history on the Coaching Group Group Type (this was enabled on production since the last backup to dev env databases)
- Checkout this branch
- Add yourself to any coaching group
- Visit /accounts/groups, see group leaders under the coaching section
- Run Group History Job
- Archive yourself from coaching group
- Visit /accounts/groups, coaching section should not be visible

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
