### PR TITLE
Page menu as table lava template

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/page-menu-table.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/page-menu-table.lava
@@ -1,0 +1,71 @@
+<style>
+    .table > tbody > tr > td {
+        vertical-align: middle;
+    }
+
+    table tr td {
+        padding: 8px 12px;
+    }
+
+    table tr th {
+        padding: 12px;
+    }
+</style>
+
+<div class="panel panel-default list clearfix">
+    <div class="panel-body hard">
+        <div class="table-responsive">
+        <table class="table table-striped table-bordered flush">
+          <tr>
+            <th width="30%">Title</th>
+            <th>Description</th>
+            <th width="12%">Action</th>
+          </tr>
+            {% for childPage in Page.Pages %}
+              <tr>
+                <td>
+                    <a href="/page/{{ childPage.Id }}" {% if childPage.DisplayDescription != 'true' %} title="{{ childPage.Description }}"{% endif %}>
+                        {% if childPage.IconCssClass != ' %}
+                            <i class="{{ childPage.IconCssClass }} fa-lg fa-fw"></i>
+                        {% endif %}
+                        <strong>{{ childPage.Title }}</strong>
+                    </a>
+                </td>
+                <td>
+                  {{ childPage.Description }}
+                </td>
+                <td>
+                  <a href="/page/{{ childPage.Id }}" class="btn btn-primary btn-block btn-sm">View Report</a>
+                </td>
+              </tr>
+            {% endfor %}
+
+            {% for page in IncludePageList %}
+                {% assign path = 'Global' | Page:'Path' %}
+                {% assign parts =  page | PropertyToKeyValue %}
+                {% if parts.Value contains '#' %}
+                    {% capture value %}{% assign valueparts = parts.Value | Split:'#' %}#{{ valueparts[1] }}{% endcapture %}
+                {% else %}
+                    {% assign value = parts.Value %}
+                {% endif %}
+              <tr>
+                <td>
+                    <a href="{{ value }}" {% if page.DisplayDescription != 'true' %} title="{{ page.Description }}"{% endif %}>
+                        {% if page.IconCssClass != ' %}
+                            <i class="{{ page.IconCssClass }} fa-lg fa-fw"></i>
+                        {% endif %}
+                        <strong>{{ parts.Key }}</strong>
+                    </a>
+                </td>
+                <td>
+                </td>
+                <td>
+                  <a href="{{ value }}" class="btn btn-primary btn-block btn-sm">View Report</a>
+                </td>
+              </tr>
+            {% endfor %}
+
+        </table>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## DESCRIPTION
Created lava template to display a pages child pages and included pages as table. This is for use mainly on report pages.

### What does this PR do, or why is it needed?
Report pages are currently using templates instead of an includes and don't currently include the included pages.

### How do I test this PR?

- [ ] Checkout page-menu-update
- [ ] Go to https://brian-rock.newspring.cc/reports/web
- [ ] In the page menu block, change the template at the bottom to {% include '~~/Assets/Lava/UI/page-menu-table.lava' %}
- [ ] Add a page that is not a child page of the current page to the included pages section of the block and save.
- [ ] Verify the included page now shows up at the bottom of the table as it's own row and that the page title link and the 'View Report' button link both work.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
