### PR TITLE
Updated lava include for location-leader to use new staff contact workflow

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -19,7 +19,9 @@
         <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
         <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
         <p>{{ leader | Attribute:'StaffBio' }}</p>
-        <p><a href="https://newspring.cc/workflows/712?StaffMember={{ leader | Property:'PrimaryAlias' | Property:'Guid' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
+        {% assign personAliasGuid = leader | Property:'PrimaryAlias' | Property:'Guid' %}
+        {% assign contactUrl = 'Global' | Attribute:'PublicApplicationRoot' | Append:'workflows/712?StaffMember=' | Append:personAliasGuid %}
+        <p><a href="{{ contactUrl }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
       </div>
     </div>
   </div>
@@ -28,8 +30,9 @@
   <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
 
     {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom {% if person.FullName == leader.FullName %}hidden{% endif %}">
-
-      {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'https://newspring.cc/workflows/712?StaffMember={{ person | Property:"PersonId" | PersonById | Property:"PrimaryAlias" | Property:"Guid" }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
+      {% assign personAliasGuid = person | Property:"PersonId" | PersonById | Property:"PrimaryAlias" | Property:"Guid" %}
+      {% assign contactUrl = 'Global' | Attribute:'PublicApplicationRoot' | Append:'workflows/712?StaffMember=' | Append:personAliasGuid %}
+      {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'{{ contactUrl }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
     </div>{% endfor %}
   </div>
 

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -2,43 +2,42 @@
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
 {% if servicetype == 'Fuse' %}
-    {% assign leader = campus.FusePastorPersonId | PersonById %}
+  {% assign leader = campus.FusePastorPersonId | PersonById %}
 {% else %}
-    {% assign leader = campus.CampusPastorPersonId | PersonById %}
+  {% assign leader = campus.CampusPastorPersonId | PersonById %}
 {% endif %}
 
 {% if campus.campusStaff != empty %}
 {[ section title:'{{ campus.Name }} Campus Staff' ]}
 
-    {% if leader != null %}
-    <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
-        <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
-            <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
-        </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
-            <div class="soft-sides xs-hard">
-                <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
-                <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
-                <p>{{ leader | Attribute:'StaffBio' }}</p>
-                <p><a href="mailto:{{ leader | Attribute:'StaffEmail' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
-            </div>
-        </div>
+  {% if leader != null %}
+  <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
+    <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
+      <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
+    </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
+      <div class="soft-sides xs-hard">
+        <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
+        <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
+        <p>{{ leader | Attribute:'StaffBio' }}</p>
+        <p><a href="https://newspring.cc/workflows/712?StaffMember={{ leader | Property:'PrimaryAlias' | Property:'Guid' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
+      </div>
     </div>
-    {% endif %}
+  </div>
+  {% endif %}
 
-    <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
+  <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
 
-        {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom  {% if person.FullName == leader.FullName %}hidden{% endif %}">
+    {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom {% if person.FullName == leader.FullName %}hidden{% endif %}">
 
-            {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'mailto:{{ person.StaffEmail }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
+      {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'https://newspring.cc/workflows/712?StaffMember={{ person | Property:"PersonId" | PersonById | Property:"PrimaryAlias" | Property:"Guid" }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
+    </div>{% endfor %}
+  </div>
 
-        </div>{% endfor %}
-    </div>
-
-    <style>
-        #staff .ratio-square {
-            margin: 0 auto;
-        }
-    </style>
+  <style>
+    #staff .ratio-square {
+      margin: 0 auto;
+    }
+  </style>
 
 {[ endsection ]}
 {% endif %}


### PR DESCRIPTION
## DESCRIPTION
Updated lava include for location-leader to use new staff contact workflow instead of mailto links.

### What does this PR do, or why is it needed?
Removes mailto links and replaces the references with the new staff contact workflow using the leaders primary alias GUID as reference.

### How do I test this PR?

- [x] Checkout leader-location-update
- [x] Go to https://brian.newspring.cc/locations/anderson
- [x] In the campus pastor information block, remove custom markup if any and make sure the block is using the following include. {% include '~~/Assets/Lava/UI/locations-leader.lava' %}
- [x] Verify that the contact buttons in the block point to workflow 712 with the different people's primary alias GUID prefilled in the query string.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
