### PR TITLE
Updated Group Leader Hub to Not Show Leaders to Group Coaches Who Have Been Archived

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/groups-landing.lava
@@ -49,7 +49,7 @@ AND gm.IsArchived = 0
 
 {% else %}
 
-  <div class="push-double-bottom">
+  <div class="push-bottom xs-push-half-bottom">
   {[ section ]}
     <div class="text-constrained mx-auto text-center">
       <h1 class="h2">Lead a Group</h1>
@@ -81,10 +81,10 @@ ON gm2.GroupRoleId = gtr.Id
 JOIN Person p
 ON gm2.PersonId = p.Id
 WHERE gm.PersonId = {{ personId }}
+AND gm.IsArchived = 0
 AND gm2.PersonId != {{ personId }} -- Omit Self From List
 AND g.GroupTypeId = 156 -- Coaching Group
 AND gm.GroupRoleId = 436 -- Is Coach
-AND gm.IsArchived = 0
 AND g.IsArchived = 0
 AND g.IsActive = 1
 AND gm2.GroupRoleId != 382
@@ -253,54 +253,3 @@ ORDER BY g2.Name, p.LastName, p.NickName
     </div>{% endfor %}
   </div>
 {% endif %}
-
-{% comment %}
-  Group Leader Resources
-{% endcomment %}
-{%- comment -%}
-{% if groups != empty or leaders != empty or coaches != empty %}
-  {% contentchannelitem where:'ContentChannelId == 714' limit:'3' sort:'StartDateTime desc' iterator:'items' %}
-    {% if items and items != empty %}
-      <h2 class="h3 xs-h5 text-uppercase strongest push-top">Leader Resources</h2>
-
-      <div class="row">
-        {% for item in items limit:3 %}<div class="col-lg-4 col-md-4 col-sm-6 col-xs-12 flush">
-
-          {% assign fallbackImage = item.ContentChannel | Attribute:'ImageLandscape' %}
-          {% assign relatedItemGuid = item | Attribute:'RelatedEntry','RawValue' | WithFallback:'',null %}
-          {% assign format = item | Attribute:'ContentFormat' %}
-          {% assign verb = item | Attribute:'ContentFormat','Object' | Attribute:'Verb' %}
-
-          {% if relatedItemGuid and relatedItemGuid != emtpy and relatedItemGuid != '' %}
-
-            {% contentchannelitem where:'Guid == "{{ relatedItemGuid }}"' iterator:'relatedItems' %}
-              {% assign relatedItem = relatedItems | First %}
-            {% endcontentchannelitem %}
-
-            {% assign title = relatedItem.Title | Replace:"'","’" %}
-            {% assign subtitle = relatedItem | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
-            {% capture permalink %}{[ getPermalink cciid:'{{ relatedItem.Id }}' ]}{% endcapture %}
-            {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:permalink %}
-            {% assign imageurl = relatedItem | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
-            {% assign target = null %}
-
-          {% else %}
-
-            {% assign title = item.Title | Replace:"'","’" %}
-            {% assign subtitle = item | Attribute:'Subtitle' | Replace:"'","’" | | WithFallback:'', null %}
-            {% assign imageurl = item | Attribute:"ImageLandscape" | WithFallback:"", fallbackImage %}
-            {% assign resourcelink = item | Attribute:'Link','RawValue' %}
-            {% assign linkurl = '/groups/resources/entry?ResourceId=' | Append:item.Id | Append:'&ResourceUrl=' | Append:resourcelink %}
-            {% assign target = '_blank' %}
-
-          {% endif %}
-
-          {[ card title:'{{ title }}' titlesize:'h4' subtitle:'{{ subtitle }}' imageurl:'{{ imageurl }}' type:'{{ format }}' linkurl:'{{ linkurl }}' linktext:'{{ verb }} {{ format }}' target:'{{ target }}' ]}
-
-        </div>{% endfor %}
-      </div>
-
-    {% endif %}
-  {% endcontentchannelitem %}
-{% endif %}
-{%- endcomment -%}


### PR DESCRIPTION
## DESCRIPTION

This addition prevents people who have been archived from coaching groups from seeing their group leaders on group leader hub. This block on production already had hard-coded lava, so I made the fix there as well. Once this change is deployed, that page can be switched back to utilizing the lava template.

### How do I test this PR?

1. Pull down this branch
2. Verify that the "My Groups" block on /account/groups is pointed to the lava include at `~~/assets/Lava/LAYOUT/groups-landing.lava`
3. Sign in as someone who has been archived from any coaching group (Daniel Young potentially has been, depending on which environment/database).
4. Go to newspring.cc/account/groups
5. The "Leaders I Coach" section should not be visible.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
