### PR TITLE
Updated swiper to use dynamic pagination to limit pagination bullet count to a maximum of three

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/swiper.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/swiper.lava
@@ -48,7 +48,7 @@
       },
       pagination: {
         el: '.swiper-pagination',
-        clickable: true,
+        dynamicBullets: true
       },
       navigation: {
         nextEl: '.swiper-next',
@@ -56,21 +56,13 @@
       },
       breakpoints: {
         1024: {
-          slidesPerView: 2.3,
+          slidesPerView: 2.3
         },
         768: {
-          speed: 100,
-          slidesPerView: 2.3,
-          pagination: {
-            dynamicBullets: true,
-          },
+          slidesPerView: 2.3
         },
         667: {
-          speed: 100,
-          slidesPerView: 1.15,
-          pagination: {
-            dynamicBullets: true,
-          },
+          slidesPerView: 1.15
         }
       }
       {% if initialslide and initialslide != empty %},


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
![image](https://user-images.githubusercontent.com/2465823/112006715-5a842980-8afa-11eb-8a79-5cd903cbfa91.png)
![image](https://user-images.githubusercontent.com/2465823/112006838-7a1b5200-8afa-11eb-9d56-d63d64406289.png)

### How do I test this PR?
1. Pull down this branch
2. View any study page
3. Swiper navigation should only show a maximum of three navigation bullets below the swiper

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
