### PR TITLE
updated editorial detail lava layout template to accept showfuturecon…

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/editorial-detail.lava
@@ -66,7 +66,21 @@
         {% assign itemsManuallyOrdered = parentItem.ChildItemsOrderedManually %}
         {% assign parentImage = parentItem.ImageLandscape %}
         {% capture parentPermalink %}{[ getPermalink cciid:'{{ parentItem.Id }}' ]}{% endcapture %}
-        {% assign totalChildren = parentItem.Children | Size %}
+
+        {% if showfuturecontent == 'true' %}
+            {% assign totalChildren = parentItem.Children | Size %}
+        {% else %}
+            {% assign now = 'Now' | Date:'yyyy-MM-ddTHH:mm:ss' %}
+            {% capture publishedItems -%}[
+                {%- for child in parentItem.Children -%}
+                    {%- if child.PublishDateTime <= now -%}
+                    {{ child | ToJSON | Append:',' }}
+                    {%- endif -%}
+                {%- endfor -%}
+            ]{%- endcapture %}
+            {% assign publishedItemsObject = publishedItems | FromJSON %}
+            {% assign totalChildren = publishedItemsObject | Size %}
+        {% endif %}
 
         {% comment %}
             Write parent interaction


### PR DESCRIPTION
…tent boolean parameter to have item pagination respect the hiding of future-dated content

## DESCRIPTION

### What does this PR do, or why is it needed?

### How do I test this PR?
1. Checkout the `update-devotionals` branch
2. Visit any devotional page within the Year of the Bible study on your test environment  - ex: https://brian.newspring.cc/devotionals/year-of-the-bible-2021/march-30-2021
3. Use the following lava to update the main devotional block on that page. The key change to note is the setting of the showfuturecontent variable (for the YOTB study only) which then gets passed to the editorial/child item swiper shortcodes, and subsequently, their templates.

```
{% assign slug = 'Global' | PageParameter:'Slug' %}
{% assign studySlug = 'Global' | PageParameter:'CollectionSlug' %}
{% assign Item = 'newspring_devotionals' | PersistedDataset | Where:'Slug',slug | First %}
{% assign parentChannelId = Item.ParentChannelId | AsInteger %}
{% assign parentId = Item.Parents | Where:'Slug', studySlug | First | Property:'Id' %}

{% comment %}
    Hide future content for Year of the Bible study only
{% endcomment %}
{% if parentId == 14054 %}
    {% assign showfuturecontent = 'false' %}
{% else %}
    {% assign showfuturecontent = 'true' %}
{% endif %}

{[ editorialDetail showfuturecontent:'{{ showfuturecontent }}' ]}

{[ childItemsSwiper title:'Devotionals From This Study' dataset:'newspring_studies' cciid:'{{ parentId }}' showfuturecontent:'{{ showfuturecontent }}' ]}
```
4. If value of `showfuturecontent` is `false`, future dated devotionals should NOT be visible in the editorial pagination section

![image](https://user-images.githubusercontent.com/2465823/113002883-3b137f00-9140-11eb-9ead-fb9155ba1d8d.png)

5. If value of `showfuturecontent` is `false`, future dated devotionals should NOT be visible in the child items swiper section

![image](https://user-images.githubusercontent.com/2465823/113002958-4797d780-9140-11eb-8f53-75a4ddb8c8eb.png)


## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [x] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [x] Review code through the lens of being concise, simple, and well-documented
- [x] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
