### PR TITLE
Removed Workflow Type Name from Rock dashboard.

### DIFF
--- a/RockWeb/Assets/Lava/MyWorkflowsSortable.lava
+++ b/RockWeb/Assets/Lava/MyWorkflowsSortable.lava
@@ -40,7 +40,7 @@
             <td>
               {% if Role == 0 %}
                 {% comment %}Role is 'Assigned To', go to WorkflowEntry page {% endcomment %}
-                <a href='/WorkflowLaunch/{{ action.Activity.Workflow.WorkflowTypeId }}/{{ action.Activity.Workflow.Guid }}'>{{ action.Activity.Workflow.Name }} ({{ action.Activity.ActivityType.Name }})</a>
+                <a href='/WorkflowLaunch/{{ action.Activity.Workflow.WorkflowTypeId }}/{{ action.Activity.Workflow.Guid }}'>{{ action.Activity.Workflow.Name }}</a>
               {% else %}
                 {% comment %}Role is 'Initiated', go to Workflow Detail page {% endcomment %}
                 <a href='/Workflow/{{ action.Activity.Workflow.Id }}'>{{ action.Activity.Workflow.Name }}</a>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This update removes the Workflow Activity Name from the displayed workflow name in a person's Rock dashboard when a workflow is assigned to them.

### How do I test this PR?
- [ ] Checkout assigned-workflows-update
- [ ] Create/assign a workflow to your dashboard and verify that it does not have the activity name after the workflow name.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
