### PR TITLE
Removed Eastlan replaces on locations hero, detail and leader sections.

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-hero.lava
@@ -1,4 +1,4 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
 
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
@@ -15,7 +15,7 @@
 {% capture id %}{% endcapture %}
 {% capture title %}{% if servicetype != 'Fuse' %}{{ 'Global' | Attribute:'OrganizationName' }}{% else %}Fuse Student Ministry{% endif %}{% endcapture %}
 {% capture titlesize %}{% endcapture %}
-{% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name | Replace:'Eastlan','Greenville' }}, SC</h3>{% endcapture %}
+{% capture content %}<p class="italic">- of -</p> <h3 class="flush">{{ campus.Name }}, SC</h3>{% endcapture %}
 {% capture textalignment %}{% endcapture %}
 {% capture label %}{% endcapture %}
 {% capture subtitle %}{% endcapture %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-information.lava
@@ -1,4 +1,4 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 {% assign mailingAddress = campus.MailingAddress %}
 {% assign officeAddress = campus.OfficeAddress %}

--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/locations-leader.lava
@@ -1,46 +1,43 @@
-{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'greenville','eastlan' | Replace:'-',' ' | Capitalize %}
+{% assign campusSlug = 'Global' | PageParameter:'CampusSlug' | Replace:'-',' ' | Capitalize %}
 {% assign campus = 'campuses' | PersistedDataset | Where:'Name', campusSlug | First %}
 
 {% if servicetype == 'Fuse' %}
-  {% assign leader = campus.FusePastorPersonId | PersonById %}
+    {% assign leader = campus.FusePastorPersonId | PersonById %}
 {% else %}
-  {% assign leader = campus.CampusPastorPersonId | PersonById %}
+    {% assign leader = campus.CampusPastorPersonId | PersonById %}
 {% endif %}
 
 {% if campus.campusStaff != empty %}
 {[ section title:'{{ campus.Name }} Campus Staff' ]}
 
-  {% if leader != null %}
-  <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
-    <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
-      <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
-    </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
-      <div class="soft-sides xs-hard">
-        <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
-        <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
-        <p>{{ leader | Attribute:'StaffBio' }}</p>
-        {% assign personAliasGuid = leader | Property:'PrimaryAlias' | Property:'Guid' %}
-        {% assign contactUrl = 'Global' | Attribute:'PublicApplicationRoot' | Append:'workflows/712?StaffMember=' | Append:personAliasGuid %}
-        <p><a href="{{ contactUrl }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
-      </div>
+    {% if leader != null %}
+    <div class="floating floating-left row soft-double-sides push-double-top xs-soft-half-sides xs-push-half-top xs-text-center sm-text-center md-text-left mx-auto" style="max-width: 1200px;">
+        <div class="floating-item col-xs-12 col-sm-12 col-md-3 push-bottom xs-push-half-bottom">
+            <div class="ratio ratio-square background-cover background-center circular" style="background-image:url('{{ leader | Attribute:'StaffImage','Url' }}'); border: 5px solid #fff; box-shadow: 0 0 2px rgba(0,0,0,.4);"></div>
+        </div><div class="floating-item col-xs-12 col-sm-12 col-md-9 push-bottom xs-push-half-ends">
+            <div class="soft-sides xs-hard">
+                <h2 class="h2 push-half-bottom">{{ leader.FullName }}</h2>
+                <h4 class="h5 text-gray-light push-half-bottom">{{ leader | Attribute:'StaffTitle' }}</h4>
+                <p>{{ leader | Attribute:'StaffBio' }}</p>
+                <p><a href="https://newspring.cc/workflows/712?StaffMember={{ leader | Property:'PrimaryAlias' | Property:'Guid' }}" class="btn btn-primary">Contact {{ leader.NickName }}</a></p>
+            </div>
+        </div>
     </div>
-  </div>
-  {% endif %}
+    {% endif %}
 
-  <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
+    <div id="staff" class="row soft-double-sides xs-soft-half-sides text-center push-double-top xs-push-half-top">
 
-    {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom {% if person.FullName == leader.FullName %}hidden{% endif %}">
-      {% assign personAliasGuid = person | Property:"PersonId" | PersonById | Property:"PrimaryAlias" | Property:"Guid" %}
-      {% assign contactUrl = 'Global' | Attribute:'PublicApplicationRoot' | Append:'workflows/712?StaffMember=' | Append:personAliasGuid %}
-      {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'{{ contactUrl }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
-    </div>{% endfor %}
-  </div>
+        {% for person in campus.CampusStaff %}<div class="col-xs-12 col-sm-6 col-md-4 push-bottom  {% if person.FullName == leader.FullName %}hidden{% endif %}">
 
-  <style>
-    #staff .ratio-square {
-      margin: 0 auto;
-    }
-  </style>
+            {[ user imageurl:'{{ person.StaffImage }}' title:'{{ person.FullName }}' subtitle:'{{ person.StaffTitle | Replace:"'","’" }}' linkurl:'https://newspring.cc/workflows/712?StaffMember={{ person | Property:"PersonId" | PersonById | Property:"PrimaryAlias" | Property:"Guid" }}' linktext:'Contact {{ person.NickName }}' ]}{[ enduser ]}
+        </div>{% endfor %}
+    </div>
+
+    <style>
+        #staff .ratio-square {
+            margin: 0 auto;
+        }
+    </style>
 
 {[ endsection ]}
 {% endif %}


### PR DESCRIPTION
## DESCRIPTION
Updated the locations page hero, details, and leader blocks to remove Eastlan replaces.

### What does this PR do, or why is it needed?
Had to remove the replaces because Eastlan has been renamed back to Greenville and they are no longer needed.

### How do I test this PR?
- [ ] Checkout locations-page-updates
- [ ] Point web config to production database since the changes to the campus name have not been made in dev environments
- [ ] Verify that /locations/greenville has the correct information displayed. Should match what is currently live on production.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
