### PR TITLE
Updated Read Your Bible link in NewSpring.cc footer

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/UI/footer.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/UI/footer.lava
@@ -52,7 +52,7 @@
         <div class="col-md-6 col-xs-12 xs-text-center">
             <p class="mb-0"> <small>© 2021 NewSpring Church</small></p>
         </div><div class="col-md-6 col-xs-12 text-right xs-text-center xs-push-half-top">
-            <p class="text-sans-serif strong text-uppercase flush"><small><a class="text-decoration-none text-gray" href="https://newspring.cc/devotionals/year-of-the-bible-2021"><i class="fas fa-sm fa-book-open" aria-hidden="true"></i>&nbsp; Read Your Bible</a></small></p>
+            <p class="text-sans-serif strong text-uppercase flush"><small><a class="text-decoration-none text-gray" href="https://newspring.cc/thebiblerecap"><i class="fas fa-sm fa-book-open" aria-hidden="true"></i>&nbsp; Read Your Bible</a></small></p>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
## DESCRIPTION
Updated the Read Your Bible link in the lower right corner of the NewSpring.cc footer to point to https://newspring.cc/thebiblerecap instead of the Year of the Bible devotional.
### What does this PR do, or why is it needed?

### How do I test this PR?
- [ ] Checkout footer-update
- [ ] Verify that the Read Your Bible link in the lower right corner of the NewSpring.cc footer points to https://newspring.cc/thebiblerecap
## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
