### PR TITLE
Updated card-list lava layout to use LinkUrl

### DIFF
--- a/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
+++ b/RockWeb/Themes/NewSpring/assets/Lava/LAYOUT/card-list.lava
@@ -99,7 +99,7 @@
 					</p>
 				{%- endcapture %}
 
-				{% capture linkurl %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ item.Id }}' ]}{% endcapture %}
+				{% capture linkurl %}{% if item.LinkUrl and item.LinkUrl != empty %}{{ item.LinkUrl }}{% else %}{[ getPermalink urlprefix:'{{ urlprefix }}' cciid:'{{ item.Id }}' ]}{% endif %}{% endcapture %}
 				{% capture linktext %}{% if cardlinktext and cardlinktext != empty %}{{ cardlinktext }}{% else %}{{ type | Prepend:' ' | Prepend:item.ChannelVerb }}{% endif %}{% endcapture %}
 
 				{% assign parentChannelId = item.ParentChannelId | AsInteger %}


### PR DESCRIPTION
This change enables the card list lava layout to use an item's LinkUrl property, if it exists, before falling back to the item's Permalink.

## DESCRIPTION

### What does this PR do, or why is it needed?

### How do I test this PR?

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Testing info includes any items that need to be added to a local Rock instance in order to test and/or the database against which it can be tested.
- [ ] Upload GIF(s) of relevant changes
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review code through the lens of being concise, simple, and well-documented
- [ ] Manual QA to ensure the changes look/behave as expected

> The purpose of PR Review is to _improve the quality of the software._
